### PR TITLE
Add Core Data persistence layer and tests

### DIFF
--- a/scoremyday2.xcodeproj/project.pbxproj
+++ b/scoremyday2.xcodeproj/project.pbxproj
@@ -6,19 +6,37 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+                9F4D72EC7CF4442DAD0B12B1 /* AppDayRangeTests.swift in Sources */ = {isa = PBXBuildFile; file = 39F5DF71227A4AFE9E8E7B3D /* AppDayRangeTests.swift */; };
+                BD136B4E922740EC92644730 /* EntriesRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; file = F7972FDA75924E0CB688140B /* EntriesRepositoryTests.swift */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
-		49AC91792E948B0500777C6A /* scoremyday2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = scoremyday2.app; sourceTree = BUILT_PRODUCTS_DIR; };
+                49AC91792E948B0500777C6A /* scoremyday2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = scoremyday2.app; sourceTree = BUILT_PRODUCTS_DIR; };
+                0EA3727FF57848ACB86820FA /* scoremyday2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = scoremyday2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+                39F5DF71227A4AFE9E8E7B3D /* AppDayRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDayRangeTests.swift; sourceTree = "<group>"; };
+                F7972FDA75924E0CB688140B /* EntriesRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntriesRepositoryTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		49AC91862E948B0600777C6A /* Exceptions for "scoremyday2" folder in "scoremyday2" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Info.plist,
+                49AC91862E948B0600777C6A /* Exceptions for "scoremyday2" folder in "scoremyday2" target */ = {
+                        isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+                        membershipExceptions = (
+                                Info.plist,
 			);
 			target = 49AC91782E948B0500777C6A /* scoremyday2 */;
-		};
+                };
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXContainerItemProxy section */
+                52C25640B8AD4796B1C92E1C /* PBXContainerItemProxy */ = {
+                        isa = PBXContainerItemProxy;
+                        containerPortal = 49AC91712E948B0500777C6A /* Project object */;
+                        proxyType = 1;
+                        remoteGlobalIDString = 49AC91782E948B0500777C6A;
+                        remoteInfo = scoremyday2;
+                };
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		49AC917B2E948B0500777C6A /* scoremyday2 */ = {
@@ -32,73 +50,121 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		49AC91762E948B0500777C6A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                49AC91762E948B0500777C6A /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                229A71376514473B88BC14FF /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		49AC91702E948B0500777C6A = {
-			isa = PBXGroup;
-			children = (
-				49AC917B2E948B0500777C6A /* scoremyday2 */,
-				49AC917A2E948B0500777C6A /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		49AC917A2E948B0500777C6A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				49AC91792E948B0500777C6A /* scoremyday2.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
+                49AC91702E948B0500777C6A = {
+                        isa = PBXGroup;
+                        children = (
+                                49AC917B2E948B0500777C6A /* scoremyday2 */,
+                                6AAB1BD55F134D7AA527823D /* scoremyday2Tests */,
+                                49AC917A2E948B0500777C6A /* Products */,
+                        );
+                        sourceTree = "<group>";
+                };
+                49AC917A2E948B0500777C6A /* Products */ = {
+                        isa = PBXGroup;
+                        children = (
+                                49AC91792E948B0500777C6A /* scoremyday2.app */,
+                                0EA3727FF57848ACB86820FA /* scoremyday2Tests.xctest */,
+                        );
+                        name = Products;
+                        sourceTree = "<group>";
+                };
+                6AAB1BD55F134D7AA527823D /* scoremyday2Tests */ = {
+                        isa = PBXGroup;
+                        children = (
+                                39F5DF71227A4AFE9E8E7B3D /* AppDayRangeTests.swift */,
+                                F7972FDA75924E0CB688140B /* EntriesRepositoryTests.swift */,
+                        );
+                        path = scoremyday2Tests;
+                        sourceTree = "<group>";
+                };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		49AC91782E948B0500777C6A /* scoremyday2 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 49AC91872E948B0600777C6A /* Build configuration list for PBXNativeTarget "scoremyday2" */;
-			buildPhases = (
-				49AC91752E948B0500777C6A /* Sources */,
-				49AC91762E948B0500777C6A /* Frameworks */,
-				49AC91772E948B0500777C6A /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				49AC917B2E948B0500777C6A /* scoremyday2 */,
-			);
-			name = scoremyday2;
-			packageProductDependencies = (
-			);
-			productName = scoremyday2;
-			productReference = 49AC91792E948B0500777C6A /* scoremyday2.app */;
-			productType = "com.apple.product-type.application";
-		};
+                49AC91782E948B0500777C6A /* scoremyday2 */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = 49AC91872E948B0600777C6A /* Build configuration list for PBXNativeTarget "scoremyday2" */;
+                        buildPhases = (
+                                49AC91752E948B0500777C6A /* Sources */,
+                                49AC91762E948B0500777C6A /* Frameworks */,
+                                49AC91772E948B0500777C6A /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                        );
+                        fileSystemSynchronizedGroups = (
+                                49AC917B2E948B0500777C6A /* scoremyday2 */,
+                        );
+                        name = scoremyday2;
+                        packageProductDependencies = (
+                        );
+                        productName = scoremyday2;
+                        productReference = 49AC91792E948B0500777C6A /* scoremyday2.app */;
+                        productType = "com.apple.product-type.application";
+                };
+                F3A3E3F650E74751A0392C36 /* scoremyday2Tests */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = 7AD8A4DEEAC14754B5020C30 /* Build configuration list for PBXNativeTarget "scoremyday2Tests" */;
+                        buildPhases = (
+                                CFD1B0BA42A9425C85C08D1E /* Sources */,
+                                229A71376514473B88BC14FF /* Frameworks */,
+                                731B4820B0A24E6B94738DDD /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                                093C3827E9F1466E997919F0 /* PBXTargetDependency */,
+                        );
+                        name = scoremyday2Tests;
+                        productName = scoremyday2Tests;
+                        productReference = 0EA3727FF57848ACB86820FA /* scoremyday2Tests.xctest */;
+                        productType = "com.apple.product-type.bundle.unit-test";
+                };
 /* End PBXNativeTarget section */
 
+/* Begin PBXTargetDependency section */
+                093C3827E9F1466E997919F0 /* PBXTargetDependency */ = {
+                        isa = PBXTargetDependency;
+                        target = 49AC91782E948B0500777C6A /* scoremyday2 */;
+                        targetProxy = 52C25640B8AD4796B1C92E1C /* PBXContainerItemProxy */;
+                };
+/* End PBXTargetDependency section */
+
 /* Begin PBXProject section */
-		49AC91712E948B0500777C6A /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2600;
-				LastUpgradeCheck = 2600;
-				TargetAttributes = {
-					49AC91782E948B0500777C6A = {
-						CreatedOnToolsVersion = 26.0.1;
-					};
-				};
-			};
-			buildConfigurationList = 49AC91742E948B0500777C6A /* Build configuration list for PBXProject "scoremyday2" */;
+                49AC91712E948B0500777C6A /* Project object */ = {
+                        isa = PBXProject;
+                        attributes = {
+                                BuildIndependentTargetsInParallel = 1;
+                                LastSwiftUpdateCheck = 2600;
+                                LastUpgradeCheck = 2600;
+                                TargetAttributes = {
+                                        49AC91782E948B0500777C6A = {
+                                                CreatedOnToolsVersion = 26.0.1;
+                                        };
+                                        F3A3E3F650E74751A0392C36 = {
+                                                CreatedOnToolsVersion = 26.0.1;
+                                                TestTargetID = 49AC91782E948B0500777C6A;
+                                        };
+                                };
+                        };
+                        buildConfigurationList = 49AC91742E948B0500777C6A /* Build configuration list for PBXProject "scoremyday2" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -111,30 +177,47 @@
 			productRefGroup = 49AC917A2E948B0500777C6A /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
-			targets = (
-				49AC91782E948B0500777C6A /* scoremyday2 */,
-			);
-		};
+                        targets = (
+                                49AC91782E948B0500777C6A /* scoremyday2 */,
+                                F3A3E3F650E74751A0392C36 /* scoremyday2Tests */,
+                        );
+                };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		49AC91772E948B0500777C6A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                49AC91772E948B0500777C6A /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                731B4820B0A24E6B94738DDD /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		49AC91752E948B0500777C6A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                49AC91752E948B0500777C6A /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                CFD1B0BA42A9425C85C08D1E /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                9F4D72EC7CF4442DAD0B12B1 /* AppDayRangeTests.swift in Sources */,
+                                BD136B4E922740EC92644730 /* EntriesRepositoryTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -270,11 +353,11 @@
 			};
 			name = Debug;
 		};
-		49AC918B2E948B0600777C6A /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+                49AC918B2E948B0600777C6A /* Release */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                ALWAYS_SEARCH_USER_PATHS = NO;
+                                ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -324,13 +407,62 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
+                        };
+                        name = Release;
+                };
+                EC18AA3CC56F4BFCB144F2E0 /* Debug */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                BUNDLE_LOADER = "$(TEST_HOST)";
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = 59Q6X62P3A;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+                                LD_RUNPATH_SEARCH_PATHS = (
+                                        "$(inherited)",
+                                        "@executable_path/Frameworks",
+                                        "@loader_path/Frameworks",
+                                );
+                                MARKETING_VERSION = 1.0;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.Donald.scoremyday2Tests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+                                SWIFT_VERSION = 5.0;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                                TEST_HOST = "$(BUILT_PRODUCTS_DIR)/scoremyday2.app/scoremyday2";
+                                TEST_TARGET_NAME = scoremyday2;
+                        };
+                        name = Debug;
+                };
+                D340B082FE9547CEB9F7D08D /* Release */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                BUNDLE_LOADER = "$(TEST_HOST)";
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = 59Q6X62P3A;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+                                LD_RUNPATH_SEARCH_PATHS = (
+                                        "$(inherited)",
+                                        "@executable_path/Frameworks",
+                                        "@loader_path/Frameworks",
+                                );
+                                MARKETING_VERSION = 1.0;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.Donald.scoremyday2Tests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_VERSION = 5.0;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                                TEST_HOST = "$(BUILT_PRODUCTS_DIR)/scoremyday2.app/scoremyday2";
+                                TEST_TARGET_NAME = scoremyday2;
+                        };
+                        name = Release;
+                };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		49AC91742E948B0500777C6A /* Build configuration list for PBXProject "scoremyday2" */ = {
+                49AC91742E948B0500777C6A /* Build configuration list for PBXProject "scoremyday2" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				49AC918A2E948B0600777C6A /* Debug */,
@@ -345,9 +477,18 @@
 				49AC91882E948B0600777C6A /* Debug */,
 				49AC91892E948B0600777C6A /* Release */,
 			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
+                7AD8A4DEEAC14754B5020C30 /* Build configuration list for PBXNativeTarget "scoremyday2Tests" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                EC18AA3CC56F4BFCB144F2E0 /* Debug */,
+                                D340B082FE9547CEB9F7D08D /* Release */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
 /* End XCConfigurationList section */
 	};
 	rootObject = 49AC91712E948B0500777C6A /* Project object */;

--- a/scoremyday2/Models/DeedModels.swift
+++ b/scoremyday2/Models/DeedModels.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+enum UnitType: Int16, CaseIterable, Codable {
+    case count
+    case duration
+    case quantity
+    case boolean
+    case rating
+}
+
+enum Polarity: Int16, CaseIterable, Codable {
+    case positive
+    case negative
+}
+
+struct DeedCard: Identifiable, Equatable {
+    var id: UUID
+    var name: String
+    var emoji: String
+    var colorHex: String
+    var category: String
+    var polarity: Polarity
+    var unitType: UnitType
+    var unitLabel: String
+    var pointsPerUnit: Double
+    var dailyCap: Double?
+    var isPrivate: Bool
+    var createdAt: Date
+    var isArchived: Bool
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        emoji: String,
+        colorHex: String,
+        category: String,
+        polarity: Polarity,
+        unitType: UnitType,
+        unitLabel: String,
+        pointsPerUnit: Double,
+        dailyCap: Double?,
+        isPrivate: Bool,
+        createdAt: Date = Date(),
+        isArchived: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.emoji = emoji
+        self.colorHex = colorHex
+        self.category = category
+        self.polarity = polarity
+        self.unitType = unitType
+        self.unitLabel = unitLabel
+        self.pointsPerUnit = pointsPerUnit
+        self.dailyCap = dailyCap
+        self.isPrivate = isPrivate
+        self.createdAt = createdAt
+        self.isArchived = isArchived
+    }
+}
+
+struct DeedEntry: Identifiable, Equatable {
+    var id: UUID
+    var deedId: UUID
+    var timestamp: Date
+    var amount: Double
+    var computedPoints: Double
+    var note: String?
+
+    init(
+        id: UUID = UUID(),
+        deedId: UUID,
+        timestamp: Date,
+        amount: Double,
+        computedPoints: Double,
+        note: String? = nil
+    ) {
+        self.id = id
+        self.deedId = deedId
+        self.timestamp = timestamp
+        self.amount = amount
+        self.computedPoints = computedPoints
+        self.note = note
+    }
+}
+
+struct AppPrefs: Identifiable, Equatable {
+    var id: UUID
+    var dayCutoffHour: Int
+    var hapticsOn: Bool
+    var soundsOn: Bool
+    var themeAccent: String?
+
+    init(
+        id: UUID = UUID(),
+        dayCutoffHour: Int = 4,
+        hapticsOn: Bool = true,
+        soundsOn: Bool = true,
+        themeAccent: String? = nil
+    ) {
+        self.id = id
+        self.dayCutoffHour = dayCutoffHour
+        self.hapticsOn = hapticsOn
+        self.soundsOn = soundsOn
+        self.themeAccent = themeAccent
+    }
+}

--- a/scoremyday2/Persistence/ManagedObjects.swift
+++ b/scoremyday2/Persistence/ManagedObjects.swift
@@ -1,0 +1,57 @@
+import CoreData
+
+@objc(DeedCardMO)
+final class DeedCardMO: NSManagedObject {
+    @NSManaged var id: UUID
+    @NSManaged var name: String
+    @NSManaged var emoji: String
+    @NSManaged var colorHex: String
+    @NSManaged var category: String
+    @NSManaged var polarityRaw: Int16
+    @NSManaged var unitTypeRaw: Int16
+    @NSManaged var unitLabel: String
+    @NSManaged var pointsPerUnit: Double
+    @NSManaged var dailyCap: NSNumber?
+    @NSManaged var isPrivate: Bool
+    @NSManaged var createdAt: Date
+    @NSManaged var isArchived: Bool
+    @NSManaged var entries: Set<DeedEntryMO>
+}
+
+extension DeedCardMO {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<DeedCardMO> {
+        NSFetchRequest<DeedCardMO>(entityName: "DeedCard")
+    }
+}
+
+@objc(DeedEntryMO)
+final class DeedEntryMO: NSManagedObject {
+    @NSManaged var id: UUID
+    @NSManaged var deedId: UUID
+    @NSManaged var timestamp: Date
+    @NSManaged var amount: Double
+    @NSManaged var computedPoints: Double
+    @NSManaged var note: String?
+    @NSManaged var deed: DeedCardMO
+}
+
+extension DeedEntryMO {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<DeedEntryMO> {
+        NSFetchRequest<DeedEntryMO>(entityName: "DeedEntry")
+    }
+}
+
+@objc(AppPrefsMO)
+final class AppPrefsMO: NSManagedObject {
+    @NSManaged var id: UUID
+    @NSManaged var dayCutoffHour: Int16
+    @NSManaged var hapticsOn: Bool
+    @NSManaged var soundsOn: Bool
+    @NSManaged var themeAccent: String?
+}
+
+extension AppPrefsMO {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<AppPrefsMO> {
+        NSFetchRequest<AppPrefsMO>(entityName: "AppPrefs")
+    }
+}

--- a/scoremyday2/Persistence/Mappings.swift
+++ b/scoremyday2/Persistence/Mappings.swift
@@ -1,0 +1,103 @@
+import CoreData
+import Foundation
+
+extension DeedCard {
+    init(managedObject: DeedCardMO) {
+        self.init(
+            id: managedObject.id,
+            name: managedObject.name,
+            emoji: managedObject.emoji,
+            colorHex: managedObject.colorHex,
+            category: managedObject.category,
+            polarity: Polarity(rawValue: managedObject.polarityRaw) ?? .positive,
+            unitType: UnitType(rawValue: managedObject.unitTypeRaw) ?? .count,
+            unitLabel: managedObject.unitLabel,
+            pointsPerUnit: managedObject.pointsPerUnit,
+            dailyCap: managedObject.dailyCap?.doubleValue,
+            isPrivate: managedObject.isPrivate,
+            createdAt: managedObject.createdAt,
+            isArchived: managedObject.isArchived
+        )
+    }
+}
+
+extension DeedCardMO {
+    func update(from card: DeedCard) {
+        id = card.id
+        name = card.name
+        emoji = card.emoji
+        colorHex = card.colorHex
+        category = card.category
+        polarityRaw = card.polarity.rawValue
+        unitTypeRaw = card.unitType.rawValue
+        unitLabel = card.unitLabel
+        pointsPerUnit = card.pointsPerUnit
+        if let cap = card.dailyCap {
+            dailyCap = NSNumber(value: cap)
+        } else {
+            dailyCap = nil
+        }
+        isPrivate = card.isPrivate
+        createdAt = card.createdAt
+        isArchived = card.isArchived
+    }
+}
+
+extension DeedEntry {
+    init(managedObject: DeedEntryMO) {
+        self.init(
+            id: managedObject.id,
+            deedId: managedObject.deedId,
+            timestamp: managedObject.timestamp,
+            amount: managedObject.amount,
+            computedPoints: managedObject.computedPoints,
+            note: managedObject.note
+        )
+    }
+}
+
+extension DeedEntryMO {
+    func update(from entry: DeedEntry, context: NSManagedObjectContext) throws {
+        id = entry.id
+        deedId = entry.deedId
+        timestamp = entry.timestamp
+        amount = entry.amount
+        computedPoints = entry.computedPoints
+        note = entry.note
+        if let deed = try context.fetchDeedCard(id: entry.deedId) {
+            self.deed = deed
+        }
+    }
+}
+
+extension AppPrefs {
+    init(managedObject: AppPrefsMO) {
+        self.init(
+            id: managedObject.id,
+            dayCutoffHour: Int(managedObject.dayCutoffHour),
+            hapticsOn: managedObject.hapticsOn,
+            soundsOn: managedObject.soundsOn,
+            themeAccent: managedObject.themeAccent
+        )
+    }
+}
+
+extension AppPrefsMO {
+    func update(from prefs: AppPrefs) {
+        id = prefs.id
+        dayCutoffHour = Int16(prefs.dayCutoffHour)
+        hapticsOn = prefs.hapticsOn
+        soundsOn = prefs.soundsOn
+        themeAccent = prefs.themeAccent
+    }
+}
+
+extension NSManagedObjectContext {
+    func fetchDeedCard(id: UUID) throws -> DeedCardMO? {
+        let request = DeedCardMO.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        let objects = try fetch(request)
+        return objects.first
+    }
+}

--- a/scoremyday2/Persistence/NSManagedObjectContext+Helpers.swift
+++ b/scoremyday2/Persistence/NSManagedObjectContext+Helpers.swift
@@ -1,0 +1,11 @@
+import CoreData
+
+extension NSManagedObjectContext {
+    func performAndReturn<T>(_ block: () throws -> T) throws -> T {
+        var result: Result<T, Error>!
+        performAndWait {
+            result = Result { try block() }
+        }
+        return try result.get()
+    }
+}

--- a/scoremyday2/Persistence/PersistenceController.swift
+++ b/scoremyday2/Persistence/PersistenceController.swift
@@ -1,12 +1,31 @@
 import CoreData
+import Foundation
+
+struct DeedCardSeed: Decodable {
+    let id: UUID?
+    let name: String
+    let emoji: String
+    let colorHex: String
+    let category: String
+    let polarity: Polarity
+    let unitType: UnitType
+    let unitLabel: String
+    let pointsPerUnit: Double
+    let dailyCap: Double?
+    let isPrivate: Bool
+    let createdAt: Date?
+    let isArchived: Bool?
+}
 
 final class PersistenceController {
     static let shared = PersistenceController()
 
     let container: NSPersistentContainer
 
+    var viewContext: NSManagedObjectContext { container.viewContext }
+
     init(inMemory: Bool = false) {
-        let model = NSManagedObjectModel()
+        let model = Self.buildModel()
         container = NSPersistentContainer(name: "ScoreMyDay", managedObjectModel: model)
 
         if inMemory {
@@ -19,5 +38,163 @@ final class PersistenceController {
             }
         }
         container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+        do {
+            try ensureAppPrefsExists()
+            try seedDefaultDeedCardsIfNeeded()
+        } catch {
+            assertionFailure("Failed to seed persistent store: \(error)")
+        }
+    }
+
+    private static func buildModel() -> NSManagedObjectModel {
+        let model = NSManagedObjectModel()
+
+        let deedCard = NSEntityDescription()
+        deedCard.name = "DeedCard"
+        deedCard.managedObjectClassName = NSStringFromClass(DeedCardMO.self)
+
+        let deedEntry = NSEntityDescription()
+        deedEntry.name = "DeedEntry"
+        deedEntry.managedObjectClassName = NSStringFromClass(DeedEntryMO.self)
+
+        let appPrefs = NSEntityDescription()
+        appPrefs.name = "AppPrefs"
+        appPrefs.managedObjectClassName = NSStringFromClass(AppPrefsMO.self)
+
+        deedCard.properties = [
+            attribute(name: "id", type: .UUIDAttributeType),
+            attribute(name: "name", type: .stringAttributeType),
+            attribute(name: "emoji", type: .stringAttributeType),
+            attribute(name: "colorHex", type: .stringAttributeType),
+            attribute(name: "category", type: .stringAttributeType),
+            attribute(name: "polarityRaw", type: .integer16AttributeType),
+            attribute(name: "unitTypeRaw", type: .integer16AttributeType),
+            attribute(name: "unitLabel", type: .stringAttributeType),
+            attribute(name: "pointsPerUnit", type: .doubleAttributeType),
+            attribute(name: "dailyCap", type: .doubleAttributeType, optional: true, allowsExternalBinaryData: false),
+            attribute(name: "isPrivate", type: .booleanAttributeType),
+            attribute(name: "createdAt", type: .dateAttributeType),
+            attribute(name: "isArchived", type: .booleanAttributeType)
+        ]
+
+        deedEntry.properties = [
+            attribute(name: "id", type: .UUIDAttributeType),
+            attribute(name: "deedId", type: .UUIDAttributeType),
+            attribute(name: "timestamp", type: .dateAttributeType),
+            attribute(name: "amount", type: .doubleAttributeType),
+            attribute(name: "computedPoints", type: .doubleAttributeType),
+            attribute(name: "note", type: .stringAttributeType, optional: true)
+        ]
+
+        appPrefs.properties = [
+            attribute(name: "id", type: .UUIDAttributeType),
+            attribute(name: "dayCutoffHour", type: .integer16AttributeType),
+            attribute(name: "hapticsOn", type: .booleanAttributeType),
+            attribute(name: "soundsOn", type: .booleanAttributeType),
+            attribute(name: "themeAccent", type: .stringAttributeType, optional: true)
+        ]
+
+        let cardToEntries = NSRelationshipDescription()
+        cardToEntries.name = "entries"
+        cardToEntries.destinationEntity = deedEntry
+        cardToEntries.deleteRule = .cascadeDeleteRule
+        cardToEntries.minCount = 0
+        cardToEntries.maxCount = 0
+        cardToEntries.isOptional = true
+        cardToEntries.isOrdered = false
+
+        let entryToCard = NSRelationshipDescription()
+        entryToCard.name = "deed"
+        entryToCard.destinationEntity = deedCard
+        entryToCard.deleteRule = .nullifyDeleteRule
+        entryToCard.minCount = 1
+        entryToCard.maxCount = 1
+        entryToCard.isOptional = false
+        entryToCard.isOrdered = false
+
+        cardToEntries.inverseRelationship = entryToCard
+        entryToCard.inverseRelationship = cardToEntries
+
+        deedCard.properties.append(cardToEntries)
+        deedEntry.properties.append(entryToCard)
+
+        model.entities = [deedCard, deedEntry, appPrefs]
+        return model
+    }
+
+    private static func attribute(
+        name: String,
+        type: NSAttributeType,
+        optional: Bool = false,
+        allowsExternalBinaryData: Bool = false
+    ) -> NSAttributeDescription {
+        let attribute = NSAttributeDescription()
+        attribute.name = name
+        attribute.attributeType = type
+        attribute.isOptional = optional
+        attribute.allowsExternalBinaryDataStorage = allowsExternalBinaryData
+        return attribute
+    }
+
+    private func ensureAppPrefsExists() throws {
+        let context = viewContext
+        let request = AppPrefsMO.fetchRequest()
+        request.fetchLimit = 1
+        let count = try context.count(for: request)
+        if count == 0 {
+            let prefs = AppPrefsMO(context: context)
+            prefs.id = UUID()
+            prefs.dayCutoffHour = 4
+            prefs.hapticsOn = true
+            prefs.soundsOn = true
+            prefs.themeAccent = nil
+            try context.save()
+        }
+    }
+
+    private func seedDefaultDeedCardsIfNeeded() throws {
+        let context = viewContext
+        let request = DeedCardMO.fetchRequest()
+        request.fetchLimit = 1
+        let count = try context.count(for: request)
+        guard count == 0 else { return }
+
+        guard let url = Bundle.main.url(forResource: "DefaultDeedCards", withExtension: "json")
+            ?? Bundle(for: PersistenceController.self).url(forResource: "DefaultDeedCards", withExtension: "json")
+        else {
+            return
+        }
+
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let seeds = try decoder.decode([DeedCardSeed].self, from: data)
+
+        for seed in seeds {
+            let card = DeedCardMO(context: context)
+            card.id = seed.id ?? UUID()
+            card.name = seed.name
+            card.emoji = seed.emoji
+            card.colorHex = seed.colorHex
+            card.category = seed.category
+            card.polarityRaw = seed.polarity.rawValue
+            card.unitTypeRaw = seed.unitType.rawValue
+            card.unitLabel = seed.unitLabel
+            card.pointsPerUnit = seed.pointsPerUnit
+            if let cap = seed.dailyCap {
+                card.dailyCap = NSNumber(value: cap)
+            } else {
+                card.dailyCap = nil
+            }
+            card.isPrivate = seed.isPrivate
+            card.createdAt = seed.createdAt ?? Date()
+            card.isArchived = seed.isArchived ?? false
+        }
+
+        if context.hasChanges {
+            try context.save()
+        }
     }
 }

--- a/scoremyday2/Repositories/AppPrefsRepository.swift
+++ b/scoremyday2/Repositories/AppPrefsRepository.swift
@@ -1,0 +1,38 @@
+import CoreData
+import Foundation
+
+final class AppPrefsRepository {
+    private let context: NSManagedObjectContext
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    func fetch() throws -> AppPrefs {
+        try context.performAndReturn {
+            let request = AppPrefsMO.fetchRequest()
+            request.fetchLimit = 1
+            if let prefs = try context.fetch(request).first {
+                return AppPrefs(managedObject: prefs)
+            } else {
+                let defaults = AppPrefs()
+                let managed = AppPrefsMO(context: context)
+                managed.update(from: defaults)
+                try context.save()
+                return defaults
+            }
+        }
+    }
+
+    func update(_ prefs: AppPrefs) throws {
+        try context.performAndWait {
+            let request = AppPrefsMO.fetchRequest()
+            request.fetchLimit = 1
+            let managed = try context.fetch(request).first ?? AppPrefsMO(context: context)
+            managed.update(from: prefs)
+            if context.hasChanges {
+                try context.save()
+            }
+        }
+    }
+}

--- a/scoremyday2/Repositories/DeedsRepository.swift
+++ b/scoremyday2/Repositories/DeedsRepository.swift
@@ -1,0 +1,48 @@
+import CoreData
+import Foundation
+
+final class DeedsRepository {
+    private let context: NSManagedObjectContext
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    func fetchAll(includeArchived: Bool = false) throws -> [DeedCard] {
+        return try context.performAndReturn {
+            let request = DeedCardMO.fetchRequest()
+            if !includeArchived {
+                request.predicate = NSPredicate(format: "isArchived == NO")
+            }
+            request.sortDescriptors = [NSSortDescriptor(key: #keyPath(DeedCardMO.createdAt), ascending: true)]
+            let objects = try context.fetch(request)
+            return objects.map(DeedCard.init(managedObject:))
+        }
+    }
+
+    func get(id: UUID) throws -> DeedCard? {
+        try context.performAndReturn {
+            try context.fetchDeedCard(id: id).map(DeedCard.init(managedObject:))
+        }
+    }
+
+    func upsert(_ card: DeedCard) throws {
+        try context.performAndWait {
+            let object = try context.fetchDeedCard(id: card.id) ?? DeedCardMO(context: context)
+            object.update(from: card)
+            if context.hasChanges {
+                try context.save()
+            }
+        }
+    }
+
+    func delete(id: UUID) throws {
+        try context.performAndWait {
+            guard let object = try context.fetchDeedCard(id: id) else { return }
+            context.delete(object)
+            if context.hasChanges {
+                try context.save()
+            }
+        }
+    }
+}

--- a/scoremyday2/Repositories/EntriesRepository.swift
+++ b/scoremyday2/Repositories/EntriesRepository.swift
@@ -1,0 +1,104 @@
+import CoreData
+import Foundation
+
+struct EntryCreationRequest {
+    var deedId: UUID
+    var timestamp: Date
+    var amount: Double
+    var note: String?
+}
+
+final class EntriesRepository {
+    private let context: NSManagedObjectContext
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    func logEntry(_ request: EntryCreationRequest, cutoffHour: Int) throws -> DeedEntry {
+        try context.performAndReturn {
+            guard let deed = try context.fetchDeedCard(id: request.deedId) else {
+                throw NSError(domain: "EntriesRepository", code: 1, userInfo: [NSLocalizedDescriptionKey: "Deed not found"])
+            }
+
+            let rawPoints = request.amount * deed.pointsPerUnit
+            let computedPoints: Double
+            if let cap = deed.dailyCap?.doubleValue, cap >= 0, rawPoints > 0 {
+                let dayRange = appDayRange(for: request.timestamp, cutoffHour: cutoffHour)
+                let existingPoints = try pointsAwarded(for: deed, within: dayRange, positiveOnly: true)
+                let remaining = max(0, cap - existingPoints)
+                computedPoints = max(0, min(rawPoints, remaining))
+            } else {
+                computedPoints = rawPoints
+            }
+
+            let entry = DeedEntryMO(context: context)
+            entry.id = UUID()
+            entry.deed = deed
+            entry.deedId = deed.id
+            entry.timestamp = request.timestamp
+            entry.amount = request.amount
+            entry.computedPoints = computedPoints
+            entry.note = request.note
+
+            if context.hasChanges {
+                try context.save()
+            }
+
+            return DeedEntry(managedObject: entry)
+        }
+    }
+
+    func fetchEntries(forDeed id: UUID? = nil, in range: ClosedRange<Date>? = nil) throws -> [DeedEntry] {
+        try context.performAndReturn {
+            let request = DeedEntryMO.fetchRequest()
+            var predicates: [NSPredicate] = []
+            if let id {
+                predicates.append(NSPredicate(format: "deedId == %@", id as CVarArg))
+            }
+            if let range {
+                predicates.append(NSPredicate(format: "timestamp >= %@ AND timestamp <= %@", range.lowerBound as NSDate, range.upperBound as NSDate))
+            }
+            if !predicates.isEmpty {
+                request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+            }
+            request.sortDescriptors = [NSSortDescriptor(key: #keyPath(DeedEntryMO.timestamp), ascending: true)]
+            let entries = try context.fetch(request)
+            return entries.map(DeedEntry.init(managedObject:))
+        }
+    }
+
+    func deleteEntry(id: UUID) throws {
+        try context.performAndWait {
+            let request = DeedEntryMO.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+            request.fetchLimit = 1
+            guard let entry = try context.fetch(request).first else { return }
+            context.delete(entry)
+            if context.hasChanges {
+                try context.save()
+            }
+        }
+    }
+
+    private func pointsAwarded(
+        for deed: DeedCardMO,
+        within range: (start: Date, end: Date),
+        positiveOnly: Bool
+    ) throws -> Double {
+        let request = DeedEntryMO.fetchRequest()
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "deed == %@", deed),
+            NSPredicate(format: "timestamp >= %@ AND timestamp < %@", range.start as NSDate, range.end as NSDate)
+        ])
+        let entries = try context.fetch(request)
+        return entries.reduce(0) { partialResult, entry in
+            let value = entry.computedPoints
+            if positiveOnly {
+                return partialResult + max(0, value)
+            } else {
+                return partialResult + value
+            }
+        }
+    }
+}

--- a/scoremyday2/Repositories/ScoresRepository.swift
+++ b/scoremyday2/Repositories/ScoresRepository.swift
@@ -1,0 +1,39 @@
+import CoreData
+import Foundation
+
+struct DailyScore: Equatable {
+    let dayStart: Date
+    let totalPoints: Double
+}
+
+final class ScoresRepository {
+    private let context: NSManagedObjectContext
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    func dailyScores(in range: ClosedRange<Date>, cutoffHour: Int) throws -> [DailyScore] {
+        try context.performAndReturn {
+            let lower = appDayRange(for: range.lowerBound, cutoffHour: cutoffHour).start
+            let upper = appDayRange(for: range.upperBound, cutoffHour: cutoffHour).end
+
+            let request = DeedEntryMO.fetchRequest()
+            request.predicate = NSPredicate(format: "timestamp >= %@ AND timestamp < %@", lower as NSDate, upper as NSDate)
+            let entries = try context.fetch(request)
+
+            var totals: [Date: Double] = [:]
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone.current
+
+            for entry in entries {
+                let bucketStart = appDayRange(for: entry.timestamp, cutoffHour: cutoffHour, calendar: calendar).start
+                totals[bucketStart, default: 0] += entry.computedPoints
+            }
+
+            return totals
+                .map { DailyScore(dayStart: $0.key, totalPoints: $0.value) }
+                .sorted { $0.dayStart < $1.dayStart }
+        }
+    }
+}

--- a/scoremyday2/Services/DemoDataService.swift
+++ b/scoremyday2/Services/DemoDataService.swift
@@ -1,0 +1,62 @@
+import CoreData
+import Foundation
+
+struct DemoDataService {
+    private let deedsRepository: DeedsRepository
+    private let entriesRepository: EntriesRepository
+    private let prefsRepository: AppPrefsRepository
+
+    init(context: NSManagedObjectContext) {
+        self.deedsRepository = DeedsRepository(context: context)
+        self.entriesRepository = EntriesRepository(context: context)
+        self.prefsRepository = AppPrefsRepository(context: context)
+    }
+
+    init(persistenceController: PersistenceController = .shared) {
+        self.init(context: persistenceController.viewContext)
+    }
+
+    func populateDemoEntriesIfNeeded() throws {
+        let existing = try entriesRepository.fetchEntries()
+        guard existing.isEmpty else { return }
+
+        let cards = try deedsRepository.fetchAll(includeArchived: false)
+        guard !cards.isEmpty else { return }
+
+        let prefs = try prefsRepository.fetch()
+        let cutoff = prefs.dayCutoffHour
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone.current
+        let now = Date()
+
+        for dayOffset in 0..<14 {
+            guard let baseDate = calendar.date(byAdding: .day, value: -dayOffset, to: now) else { continue }
+            let dayStart = appDayRange(for: baseDate, cutoffHour: cutoff, calendar: calendar).start
+
+            for (index, card) in cards.prefix(3).enumerated() where !card.isPrivate {
+                let timestamp = calendar.date(byAdding: .hour, value: 2 + index * 3, to: dayStart) ?? dayStart
+                let amount = amountForDemo(index: index, dayOffset: dayOffset, unitType: card.unitType)
+                let request = EntryCreationRequest(
+                    deedId: card.id,
+                    timestamp: timestamp,
+                    amount: amount,
+                    note: "Demo entry"
+                )
+                _ = try entriesRepository.logEntry(request, cutoffHour: cutoff)
+            }
+        }
+    }
+
+    private func amountForDemo(index: Int, dayOffset: Int, unitType: UnitType) -> Double {
+        let base = Double((index + dayOffset) % 3 + 1)
+        switch unitType {
+        case .boolean:
+            return 1
+        case .rating:
+            return min(5, base + 2)
+        default:
+            return base
+        }
+    }
+}

--- a/scoremyday2/Utilities/AppDayRange.swift
+++ b/scoremyday2/Utilities/AppDayRange.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Returns the start and end boundaries for an "app day" using the provided cutoff hour.
+/// The returned range is half-open: start <= date < end.
+func appDayRange(
+    for date: Date,
+    cutoffHour: Int,
+    calendar inputCalendar: Calendar = Calendar(identifier: .gregorian)
+) -> (start: Date, end: Date) {
+    var calendar = inputCalendar
+    calendar.timeZone = inputCalendar.timeZone
+    calendar.locale = inputCalendar.locale
+
+    let adjusted = calendar.date(byAdding: .hour, value: -cutoffHour, to: date) ?? date
+    let dayStart = calendar.startOfDay(for: adjusted)
+    let rangeStart = calendar.date(byAdding: .hour, value: cutoffHour, to: dayStart) ?? dayStart
+    let rangeEnd = calendar.date(byAdding: .day, value: 1, to: rangeStart) ?? rangeStart
+    return (start: rangeStart, end: rangeEnd)
+}

--- a/scoremyday2Tests/AppDayRangeTests.swift
+++ b/scoremyday2Tests/AppDayRangeTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import scoremyday2
+
+final class AppDayRangeTests: XCTestCase {
+    func testAppDayRangeBeforeCutoffUsesPreviousDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let reference = calendar.date(from: DateComponents(year: 2024, month: 1, day: 10, hour: 2))!
+        let range = appDayRange(for: reference, cutoffHour: 4, calendar: calendar)
+
+        let expectedStart = calendar.date(from: DateComponents(year: 2024, month: 1, day: 9, hour: 4))!
+        let expectedEnd = calendar.date(from: DateComponents(year: 2024, month: 1, day: 10, hour: 4))!
+
+        XCTAssertEqual(range.start, expectedStart)
+        XCTAssertEqual(range.end, expectedEnd)
+    }
+
+    func testAppDayRangeAfterCutoffUsesSameDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let reference = calendar.date(from: DateComponents(year: 2024, month: 1, day: 10, hour: 16))!
+        let range = appDayRange(for: reference, cutoffHour: 4, calendar: calendar)
+
+        let expectedStart = calendar.date(from: DateComponents(year: 2024, month: 1, day: 10, hour: 4))!
+        let expectedEnd = calendar.date(from: DateComponents(year: 2024, month: 1, day: 11, hour: 4))!
+
+        XCTAssertEqual(range.start, expectedStart)
+        XCTAssertEqual(range.end, expectedEnd)
+    }
+}

--- a/scoremyday2Tests/EntriesRepositoryTests.swift
+++ b/scoremyday2Tests/EntriesRepositoryTests.swift
@@ -1,0 +1,61 @@
+import CoreData
+import XCTest
+@testable import scoremyday2
+
+final class EntriesRepositoryTests: XCTestCase {
+    var persistence: PersistenceController!
+    var entriesRepository: EntriesRepository!
+    var deedsRepository: DeedsRepository!
+
+    override func setUpWithError() throws {
+        persistence = PersistenceController(inMemory: true)
+        let context = persistence.viewContext
+        deedsRepository = DeedsRepository(context: context)
+        entriesRepository = EntriesRepository(context: context)
+    }
+
+    override func tearDownWithError() throws {
+        persistence = nil
+        entriesRepository = nil
+        deedsRepository = nil
+    }
+
+    func testDailyCapLimitsPointsPerAppDay() throws {
+        let card = DeedCard(
+            name: "Meditation",
+            emoji: "🧘",
+            colorHex: "#FFFFFF",
+            category: "Wellness",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "minutes",
+            pointsPerUnit: 5,
+            dailyCap: 10,
+            isPrivate: false
+        )
+        try deedsRepository.upsert(card)
+
+        let timestamp = Date()
+        let first = try entriesRepository.logEntry(
+            EntryCreationRequest(deedId: card.id, timestamp: timestamp, amount: 1, note: nil),
+            cutoffHour: 4
+        )
+        XCTAssertEqual(first.computedPoints, 5)
+
+        let second = try entriesRepository.logEntry(
+            EntryCreationRequest(deedId: card.id, timestamp: timestamp.addingTimeInterval(3600), amount: 2, note: nil),
+            cutoffHour: 4
+        )
+        XCTAssertEqual(second.computedPoints, 5)
+
+        let third = try entriesRepository.logEntry(
+            EntryCreationRequest(deedId: card.id, timestamp: timestamp.addingTimeInterval(7200), amount: 1, note: nil),
+            cutoffHour: 4
+        )
+        XCTAssertEqual(third.computedPoints, 0)
+
+        let entries = try entriesRepository.fetchEntries(forDeed: card.id)
+        XCTAssertEqual(entries.count, 3)
+        XCTAssertEqual(entries.map { $0.computedPoints }, [5, 5, 0])
+    }
+}


### PR DESCRIPTION
## Summary
- build a programmatic Core Data model, seed logic, and helper types for the new DeedCard, DeedEntry, and AppPrefs entities
- add repositories for deeds, entries, scores, and app preferences plus a demo data service and app-day helper utilities
- wire up an iOS unit test target with coverage for app-day bucketing and daily point caps

## Testing
- not run (xcodebuild is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e45e950ea08331b474e208eaa1a614