### PR TITLE
Add default data seeding and QA demo loader

### DIFF
--- a/scoremyday2/Services/DemoDataService.swift
+++ b/scoremyday2/Services/DemoDataService.swift
@@ -2,11 +2,13 @@ import CoreData
 import Foundation
 
 struct DemoDataService {
+    private let context: NSManagedObjectContext
     private let deedsRepository: DeedsRepository
     private let entriesRepository: EntriesRepository
     private let prefsRepository: AppPrefsRepository
 
     init(context: NSManagedObjectContext) {
+        self.context = context
         self.deedsRepository = DeedsRepository(context: context)
         self.entriesRepository = EntriesRepository(context: context)
         self.prefsRepository = AppPrefsRepository(context: context)
@@ -16,11 +18,11 @@ struct DemoDataService {
         self.init(context: persistenceController.viewContext)
     }
 
-    func populateDemoEntriesIfNeeded() throws {
-        let existing = try entriesRepository.fetchEntries()
-        guard existing.isEmpty else { return }
+    func loadDemoData() throws {
+        try clearExistingData()
+        _ = try InitialDataSeeder(context: context).seedDefaultDeedCards()
 
-        let cards = try deedsRepository.fetchAll(includeArchived: false)
+        let cards = try deedsRepository.fetchAll(includeArchived: false).filter { !$0.isArchived }
         guard !cards.isEmpty else { return }
 
         let prefs = try prefsRepository.fetch()
@@ -31,32 +33,65 @@ struct DemoDataService {
         let now = Date()
 
         for dayOffset in 0..<14 {
-            guard let baseDate = calendar.date(byAdding: .day, value: -dayOffset, to: now) else { continue }
-            let dayStart = appDayRange(for: baseDate, cutoffHour: cutoff, calendar: calendar).start
+            guard let referenceDate = calendar.date(byAdding: .day, value: -dayOffset, to: now) else { continue }
+            let dayRange = appDayRange(for: referenceDate, cutoffHour: cutoff, calendar: calendar)
+            let entryCount = Int.random(in: 10...30)
 
-            for (index, card) in cards.prefix(3).enumerated() where !card.isPrivate {
-                let timestamp = calendar.date(byAdding: .hour, value: 2 + index * 3, to: dayStart) ?? dayStart
-                let amount = amountForDemo(index: index, dayOffset: dayOffset, unitType: card.unitType)
+            for _ in 0..<entryCount {
+                guard let card = cards.randomElement() else { continue }
+                let timestamp = randomTimestamp(in: dayRange)
+                let amount = randomAmount(for: card)
+                let note = Bool.random() ? nil : "Demo entry"
                 let request = EntryCreationRequest(
                     deedId: card.id,
                     timestamp: timestamp,
                     amount: amount,
-                    note: "Demo entry"
+                    note: note
                 )
                 _ = try entriesRepository.logEntry(request, cutoffHour: cutoff)
             }
         }
     }
 
-    private func amountForDemo(index: Int, dayOffset: Int, unitType: UnitType) -> Double {
-        let base = Double((index + dayOffset) % 3 + 1)
-        switch unitType {
+    private func clearExistingData() throws {
+        try context.performAndReturn {
+            let entryRequest = DeedEntryMO.fetchRequest()
+            let entries = try context.fetch(entryRequest)
+            entries.forEach(context.delete)
+
+            let cardRequest = DeedCardMO.fetchRequest()
+            let cards = try context.fetch(cardRequest)
+            cards.forEach(context.delete)
+
+            if context.hasChanges {
+                try context.save()
+            }
+        }
+    }
+
+    private func randomTimestamp(in range: (start: Date, end: Date)) -> Date {
+        let interval = max(1, range.end.timeIntervalSince(range.start))
+        let offset = TimeInterval.random(in: 0..<interval)
+        return range.start.addingTimeInterval(offset)
+    }
+
+    private func randomAmount(for card: DeedCard) -> Double {
+        switch card.unitType {
         case .boolean:
             return 1
         case .rating:
-            return min(5, base + 2)
-        default:
-            return base
+            return Double(Int.random(in: 1...5))
+        case .count:
+            return Double(Int.random(in: 1...4))
+        case .duration:
+            let minutes = Int.random(in: 2...24) * 5
+            return Double(minutes)
+        case .quantity:
+            if card.polarity == .positive {
+                return Double(Int.random(in: 1...8) * 250)
+            } else {
+                return Double(Int.random(in: 1...3))
+            }
         }
     }
 }

--- a/scoremyday2/Services/InitialDataSeeder.swift
+++ b/scoremyday2/Services/InitialDataSeeder.swift
@@ -1,0 +1,227 @@
+import CoreData
+import Foundation
+
+struct DefaultDeedCardSeed {
+    let name: String
+    let emoji: String
+    let category: String
+    let polarity: Polarity
+    let unitType: UnitType
+    let unitLabel: String
+    let pointsPerUnit: Double
+    let dailyCap: Double?
+    let colorHex: String
+    let isPrivate: Bool
+}
+
+struct InitialDataSeeder {
+    private let context: NSManagedObjectContext
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    func runIfNeeded() throws {
+        guard try shouldSeedDefaults() else { return }
+        try seedDefaultDeedCards()
+    }
+
+    @discardableResult
+    func seedDefaultDeedCards() throws -> [DeedCardMO] {
+        try context.performAndReturn {
+            var createdCards: [DeedCardMO] = []
+            let now = Date()
+
+            for (index, seed) in DefaultDeedCardSeed.all.enumerated() {
+                let card = DeedCardMO(context: context)
+                card.id = UUID()
+                card.name = seed.name
+                card.emoji = seed.emoji
+                card.colorHex = seed.colorHex
+                card.category = seed.category
+                card.polarityRaw = seed.polarity.rawValue
+                card.unitTypeRaw = seed.unitType.rawValue
+                card.unitLabel = seed.unitLabel
+                card.pointsPerUnit = seed.pointsPerUnit
+                if let cap = seed.dailyCap {
+                    card.dailyCap = NSNumber(value: cap)
+                } else {
+                    card.dailyCap = nil
+                }
+                card.isPrivate = seed.isPrivate
+                card.createdAt = now.addingTimeInterval(TimeInterval(-index * 60))
+                card.isArchived = false
+                createdCards.append(card)
+            }
+
+            if context.hasChanges {
+                try context.save()
+            }
+
+            return createdCards
+        }
+    }
+
+    private func shouldSeedDefaults() throws -> Bool {
+        try context.performAndReturn {
+            let cardRequest = DeedCardMO.fetchRequest()
+            cardRequest.fetchLimit = 1
+            let cardCount = try context.count(for: cardRequest)
+            guard cardCount == 0 else { return false }
+
+            let entryRequest = DeedEntryMO.fetchRequest()
+            entryRequest.fetchLimit = 1
+            let entryCount = try context.count(for: entryRequest)
+            return entryCount == 0
+        }
+    }
+}
+
+private extension DefaultDeedCardSeed {
+    static let all: [DefaultDeedCardSeed] = [
+        DefaultDeedCardSeed(
+            name: "Brush Teeth",
+            emoji: "🪥",
+            category: "Health",
+            polarity: .positive,
+            unitType: .count,
+            unitLabel: "time",
+            pointsPerUnit: 5,
+            dailyCap: 2,
+            colorHex: "#5ED3F3",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Pray",
+            emoji: "🙏",
+            category: "Faith",
+            polarity: .positive,
+            unitType: .count,
+            unitLabel: "rak'ah",
+            pointsPerUnit: 20,
+            dailyCap: nil,
+            colorHex: "#9B59B6",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Read Book",
+            emoji: "📖",
+            category: "Learning",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "min",
+            pointsPerUnit: 1.5,
+            dailyCap: 120,
+            colorHex: "#F5B041",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Meditation",
+            emoji: "🧘",
+            category: "Wellbeing",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "min",
+            pointsPerUnit: 2,
+            dailyCap: 60,
+            colorHex: "#2ECC71",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Drink Water",
+            emoji: "💧",
+            category: "Health",
+            polarity: .positive,
+            unitType: .quantity,
+            unitLabel: "ml",
+            pointsPerUnit: 0.02,
+            dailyCap: 4000,
+            colorHex: "#3498DB",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Family Time",
+            emoji: "👨‍👩‍👧",
+            category: "Relationships",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "min",
+            pointsPerUnit: 1,
+            dailyCap: 180,
+            colorHex: "#E67E22",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Workout",
+            emoji: "🏋️",
+            category: "Health",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "min",
+            pointsPerUnit: 2.5,
+            dailyCap: 120,
+            colorHex: "#E74C3C",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "No Phone after 10pm",
+            emoji: "📵",
+            category: "Habits",
+            polarity: .positive,
+            unitType: .boolean,
+            unitLabel: "did it",
+            pointsPerUnit: 20,
+            dailyCap: 1,
+            colorHex: "#16A085",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Junk Food",
+            emoji: "🍟",
+            category: "Diet",
+            polarity: .negative,
+            unitType: .quantity,
+            unitLabel: "serving",
+            pointsPerUnit: -15,
+            dailyCap: nil,
+            colorHex: "#C0392B",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Smoked",
+            emoji: "🚭",
+            category: "Addiction",
+            polarity: .negative,
+            unitType: .boolean,
+            unitLabel: "did it",
+            pointsPerUnit: -40,
+            dailyCap: nil,
+            colorHex: "#8E44AD",
+            isPrivate: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Doomscrolling",
+            emoji: "📱",
+            category: "Habits",
+            polarity: .negative,
+            unitType: .duration,
+            unitLabel: "min",
+            pointsPerUnit: -1,
+            dailyCap: nil,
+            colorHex: "#7F8C8D",
+            isPrivate: false
+        ),
+        DefaultDeedCardSeed(
+            name: "Focus Rating",
+            emoji: "🎯",
+            category: "Work",
+            polarity: .positive,
+            unitType: .rating,
+            unitLabel: "stars",
+            pointsPerUnit: 4,
+            dailyCap: 5,
+            colorHex: "#F1C40F",
+            isPrivate: false
+        )
+    ]
+}

--- a/scoremyday2/UI/Pages/SettingsPage.swift
+++ b/scoremyday2/UI/Pages/SettingsPage.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct SettingsPage: View {
     @EnvironmentObject private var appEnvironment: AppEnvironment
+    @State private var isLoadingDemoData = false
+    @State private var demoDataError: String?
 
     var body: some View {
         NavigationStack {
@@ -25,8 +27,55 @@ struct SettingsPage: View {
                         }
                     ))
                 }
+
+                Section("QA") {
+                    Toggle(isOn: Binding(
+                        get: { false },
+                        set: { newValue in
+                            guard newValue else { return }
+                            loadDemoData()
+                        }
+                    )) {
+                        HStack {
+                            Text("Load Demo Data")
+                            if isLoadingDemoData {
+                                Spacer()
+                                ProgressView()
+                            }
+                        }
+                    }
+                    .disabled(isLoadingDemoData)
+                }
             }
             .navigationTitle("Settings")
+            .alert("Unable to Load Demo Data", isPresented: Binding(
+                get: { demoDataError != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        demoDataError = nil
+                    }
+                }
+            )) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(demoDataError ?? "")
+            }
+        }
+    }
+
+    private func loadDemoData() {
+        guard !isLoadingDemoData else { return }
+        isLoadingDemoData = true
+
+        Task { @MainActor in
+            defer { isLoadingDemoData = false }
+
+            do {
+                let service = DemoDataService(persistenceController: appEnvironment.persistenceController)
+                try service.loadDemoData()
+            } catch {
+                demoDataError = error.localizedDescription
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an InitialDataSeeder that seeds the built-in DeedCards when the store is empty
- expand DemoDataService to reset data and generate randomized demo entries for the last two weeks
- add a QA toggle in Settings to trigger loading demo data with progress and error handling

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4628c9ba883318e1c17ee950feb4b