### PR TITLE
Add glass background component and apply across main views

### DIFF
--- a/scoremyday2/UI/Components/DeedIconView.swift
+++ b/scoremyday2/UI/Components/DeedIconView.swift
@@ -9,14 +9,17 @@ import AppKit
 struct DeedIconView: View {
     let value: String
     var fontSize: CGFloat = 30
+    var tint: Color?
 
     var body: some View {
         Group {
             if let symbolName = symbolNameIfValid(value) {
                 Image(systemName: symbolName)
                     .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(tint ?? .primary)
             } else {
                 Text(value)
+                    .foregroundStyle(tint ?? .primary)
             }
         }
         .font(.system(size: fontSize))

--- a/scoremyday2/UI/Components/GlassBackground.swift
+++ b/scoremyday2/UI/Components/GlassBackground.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct GlassBackgroundModifier: ViewModifier {
+    var cornerRadius: CGFloat
+    var tint: Color
+    var warpStrength: CGFloat
+
+    @State private var targetLocation: CGPoint?
+    @State private var animatedLocation: CGPoint?
+    @State private var isInteracting = false
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                GlassMaterialView(
+                    cornerRadius: cornerRadius,
+                    tint: tint,
+                    warpStrength: warpStrength,
+                    interactionLocation: animatedLocation,
+                    isInteracting: isInteracting
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .simultaneousGesture(dragGesture)
+            .onChange(of: targetLocation) { newValue in
+                withAnimation(.easeOut(duration: 0.28)) {
+                    animatedLocation = newValue
+                }
+            }
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                targetLocation = value.location
+                if !isInteracting {
+                    isInteracting = true
+                }
+            }
+            .onEnded { _ in
+                targetLocation = nil
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.85)) {
+                    animatedLocation = nil
+                }
+                isInteracting = false
+            }
+    }
+}
+
+extension View {
+    func glassBackground(
+        cornerRadius: CGFloat = 20,
+        tint: Color = .accentColor,
+        warpStrength: CGFloat = 4
+    ) -> some View {
+        modifier(GlassBackgroundModifier(cornerRadius: cornerRadius, tint: tint, warpStrength: warpStrength))
+    }
+}
+
+private struct GlassMaterialView: View {
+    var cornerRadius: CGFloat
+    var tint: Color
+    var warpStrength: CGFloat
+    var interactionLocation: CGPoint?
+    var isInteracting: Bool
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityContrast) private var contrast
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        GeometryReader { proxy in
+            let size = proxy.size
+            let normalized = normalizedPoint(in: size)
+            let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            let offset = lensOffset(normalized: normalized)
+            let scale = lensScale(normalized: normalized)
+
+            shape
+                .fill(.ultraThinMaterial)
+                .background(
+                    shape
+                        .fill(tintGradient(normalized: normalized))
+                )
+                .overlay(innerHighlight(shape: shape, normalized: normalized))
+                .overlay(glassBorder(shape: shape))
+                .shadow(color: shadowColor, radius: shadowRadius, x: 0, y: shadowYOffset)
+                .scaleEffect(1 + scale)
+                .offset(offset)
+                .animation(.easeOut(duration: 0.35), value: normalized.x)
+                .animation(.easeOut(duration: 0.35), value: normalized.y)
+        }
+    }
+
+    private func normalizedPoint(in size: CGSize) -> CGPoint {
+        guard size.width > 0, size.height > 0 else { return CGPoint(x: 0.5, y: 0.5) }
+        guard let location = interactionLocation else { return CGPoint(x: 0.5, y: 0.5) }
+        let x = max(0, min(location.x / size.width, 1))
+        let y = max(0, min(location.y / size.height, 1))
+        return CGPoint(x: x, y: y)
+    }
+
+    private func tintGradient(normalized: CGPoint) -> LinearGradient {
+        let baseOpacity = contrast == .increased ? 0.55 : 0.35
+        let secondaryOpacity = contrast == .increased ? 0.42 : 0.25
+        let tertiaryOpacity = contrast == .increased ? 0.25 : 0.15
+        let adjustedTint = tint.opacity(colorScheme == .dark ? baseOpacity : baseOpacity * 0.8)
+        let gradientColors: [Color] = [
+            adjustedTint,
+            tint.opacity(colorScheme == .dark ? secondaryOpacity : secondaryOpacity * 0.8),
+            Color.white.opacity(colorScheme == .dark ? tertiaryOpacity : tertiaryOpacity * 1.6)
+        ]
+        let start = UnitPoint(x: normalized.x * 0.6, y: max(normalized.y - 0.3, 0))
+        let end = UnitPoint(x: 1 - normalized.x * 0.4, y: 1)
+        return LinearGradient(colors: gradientColors, startPoint: start, endPoint: end)
+    }
+
+    private func innerHighlight(shape: RoundedRectangle, normalized: CGPoint) -> some View {
+        let highlightOpacity = contrast == .increased ? 0.75 : 0.55
+        let highlightGradient = LinearGradient(
+            colors: [
+                Color.white.opacity(highlightOpacity),
+                Color.white.opacity(0.1)
+            ],
+            startPoint: UnitPoint(x: normalized.x * 0.8, y: 0),
+            endPoint: UnitPoint(x: 1, y: 1)
+        )
+        let glow = shape
+            .stroke(highlightGradient, lineWidth: contrast == .increased ? 1.8 : 1.1)
+            .blendMode(.screen)
+            .opacity(0.65)
+
+        let innerShadow = shape
+            .stroke(Color.black.opacity(colorScheme == .dark ? 0.45 : 0.12), lineWidth: 1)
+            .blur(radius: 1.2)
+            .offset(x: 0, y: 1.2)
+            .mask(shape)
+            .opacity(0.5)
+
+        return glow.overlay(innerShadow)
+    }
+
+    private func glassBorder(shape: RoundedRectangle) -> some View {
+        let borderColor = tint.opacity(colorScheme == .dark ? 0.35 : 0.25)
+        return shape
+            .strokeBorder(borderColor, lineWidth: contrast == .increased ? 1.6 : 1)
+            .blendMode(.plusLighter)
+            .opacity(cornerRadius < 1 ? 0 : 0.8)
+    }
+
+    private var shadowColor: Color {
+        guard cornerRadius > 0.5 else { return .clear }
+        let baseOpacity: Double = colorScheme == .dark ? 0.55 : 0.25
+        return Color.black.opacity(contrast == .increased ? baseOpacity * 0.6 : baseOpacity)
+    }
+
+    private var shadowRadius: CGFloat {
+        guard cornerRadius > 0.5 else { return 0 }
+        return contrast == .increased ? 10 : 18
+    }
+
+    private var shadowYOffset: CGFloat {
+        guard cornerRadius > 0.5 else { return 0 }
+        return contrast == .increased ? 6 : 12
+    }
+
+    private func lensOffset(normalized: CGPoint) -> CGSize {
+        guard !reduceMotion else { return .zero }
+        let clampedStrength = min(max(warpStrength, 0), 6)
+        let multiplier: CGFloat = isInteracting ? 1 : 0.55
+        let x = (normalized.x - 0.5) * clampedStrength * multiplier
+        let y = (normalized.y - 0.5) * clampedStrength * multiplier
+        return CGSize(width: x, height: y)
+    }
+
+    private func lensScale(normalized: CGPoint) -> CGFloat {
+        guard !reduceMotion else { return 0 }
+        let distance = sqrt(pow(normalized.x - 0.5, 2) + pow(normalized.y - 0.5, 2))
+        let maxScale: CGFloat = (contrast == .increased ? 0.008 : 0.012) * (isInteracting ? 1 : 0.6)
+        return max(0, (1 - min(distance * 2, 1)) * maxScale)
+    }
+}

--- a/scoremyday2/UI/Pages/DeedsPage.swift
+++ b/scoremyday2/UI/Pages/DeedsPage.swift
@@ -84,15 +84,15 @@ struct DeedsPage: View {
                 Text("TODAY")
                     .font(.caption.weight(.semibold))
                     .textCase(.uppercase)
-                    .foregroundColor(.white.opacity(0.7))
+                    .foregroundStyle(.secondary)
 
                 Text(formattedPoints(viewModel.todayNetScore))
                     .font(.system(size: 34, weight: .bold, design: .rounded))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
 
                 Text("resets at \(formattedCutoffHour())")
                     .font(.caption2)
-                    .foregroundColor(.white.opacity(0.7))
+                    .foregroundStyle(.secondary)
             }
 
             Spacer()
@@ -102,13 +102,7 @@ struct DeedsPage: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 18)
-        .background(.ultraThinMaterial.opacity(0.75))
-        .clipShape(Capsule())
-        .overlay(
-            Capsule()
-                .stroke(Color.white.opacity(0.18), lineWidth: 1)
-        )
-        .shadow(color: Color.black.opacity(0.2), radius: 14, x: 0, y: 12)
+        .glassBackground(cornerRadius: 32, tint: Color.accentColor, warpStrength: 3.5)
     }
 
     private var cardsGrid: some View {
@@ -281,38 +275,31 @@ private struct DeedCardTile: View {
     let onEdit: () -> Void
 
     var body: some View {
-        let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
         ZStack(alignment: .topLeading) {
-            shape
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    shape.stroke(state.accentColor.opacity(0.6), lineWidth: 1.5)
-                )
-
             VStack(alignment: .leading, spacing: 10) {
-                DeedIconView(value: state.card.emoji)
+                DeedIconView(value: state.card.emoji, tint: state.accentColor)
 
                 Text(state.card.name)
                     .font(.headline)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.primary)
                     .lineLimit(1)
 
                 Text(state.card.unitLabel)
                     .font(.caption)
-                    .foregroundColor(.white.opacity(0.7))
+                    .foregroundStyle(.secondary)
             }
             .padding(16)
 
             if state.card.isPrivate {
                 Image(systemName: "eye.slash.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundColor(.white.opacity(0.5))
+                    .foregroundStyle(.secondary)
                     .padding(10)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             }
         }
         .frame(height: 120)
-        .contentShape(shape)
+        .glassBackground(cornerRadius: 20, tint: state.accentColor, warpStrength: 3.5)
         .onTapGesture { onTap() }
         .contextMenu {
             Button {
@@ -334,22 +321,18 @@ private struct AddCardTile: View {
     let action: () -> Void
 
     var body: some View {
-        let shape = RoundedRectangle(cornerRadius: 20, style: .continuous)
-        shape
-            .fill(.ultraThinMaterial)
-            .overlay(
-                VStack(spacing: 8) {
-                    Image(systemName: "plus")
-                        .font(.system(size: 24, weight: .bold))
-                    Text("New")
-                        .font(.subheadline.weight(.semibold))
-                }
-                .foregroundColor(.white)
-            )
-            .overlay(shape.stroke(Color.white.opacity(0.25), lineWidth: 1))
-            .frame(height: 120)
-            .contentShape(shape)
-            .onTapGesture { action() }
+        VStack(spacing: 8) {
+            Image(systemName: "plus")
+                .font(.system(size: 24, weight: .bold))
+            Text("New")
+                .font(.subheadline.weight(.semibold))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .foregroundStyle(.primary)
+        .frame(height: 120)
+        .glassBackground(cornerRadius: 20, tint: Color.accentColor, warpStrength: 3)
+        .contentShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .onTapGesture { action() }
     }
 }
 

--- a/scoremyday2/UI/Pages/RootView.swift
+++ b/scoremyday2/UI/Pages/RootView.swift
@@ -4,22 +4,32 @@ struct RootView: View {
     @EnvironmentObject private var appEnvironment: AppEnvironment
 
     var body: some View {
-        TabView {
-            DeedsPage()
-                .tabItem {
-                    Label("Deeds", systemImage: "square.grid.3x3")
-                }
+        ZStack {
+            LiquidBackgroundView()
+                .ignoresSafeArea()
 
-            StatsPage()
-                .tabItem {
-                    Label("Stats", systemImage: "chart.xyaxis.line")
-                }
+            TabView {
+                DeedsPage()
+                    .tabItem {
+                        Label("Deeds", systemImage: "square.grid.3x3")
+                    }
 
-            SettingsPage()
-                .tabItem {
-                    Label("Settings", systemImage: "gearshape")
-                }
+                StatsPage()
+                    .tabItem {
+                        Label("Stats", systemImage: "chart.xyaxis.line")
+                    }
+
+                SettingsPage()
+                    .tabItem {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+            }
         }
+        .glassBackground(
+            cornerRadius: 0,
+            tint: Color(appEnvironment.settings.accentColorIdentifier),
+            warpStrength: 2
+        )
         .accentColor(Color(appEnvironment.settings.accentColorIdentifier))
     }
 }

--- a/scoremyday2/UI/Pages/StatsPage.swift
+++ b/scoremyday2/UI/Pages/StatsPage.swift
@@ -187,7 +187,7 @@ struct StatsPage: View {
             }
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .glassBackground(cornerRadius: 16, tint: Color.accentColor, warpStrength: 2.5)
         }
     }
 
@@ -249,7 +249,7 @@ private struct ContributionChartView: View {
         }
         .padding()
         .frame(maxWidth: .infinity)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .glassBackground(cornerRadius: 16, tint: Color.accentColor, warpStrength: 2.5)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable glass background modifier with tinted gradient, highlights, and warp shimmer motion
- refresh the root view, deeds cards, and stats surfaces to adopt the new glass styling with accessible colors
- allow deed icons to receive tinting so cards stay consistent with their accent hues

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e496c08fe88331a22e64da62f3ac41