### PR TITLE
Add queued floating score animation

### DIFF
--- a/scoremyday2/UI/Utilities/FloatingDeltaQueue.swift
+++ b/scoremyday2/UI/Utilities/FloatingDeltaQueue.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct FloatingDeltaQueue {
+    private let spacing: TimeInterval
+    private var nextAvailableStart: Date?
+
+    init(spacing: TimeInterval = 0.08) {
+        self.spacing = spacing
+    }
+
+    mutating func nextDelay(now: Date = Date()) -> TimeInterval {
+        guard let nextAvailableStart else {
+            self.nextAvailableStart = now.addingTimeInterval(spacing)
+            return 0
+        }
+
+        let earliestStart = max(now, nextAvailableStart)
+        let delay = max(0, earliestStart.timeIntervalSince(now))
+        self.nextAvailableStart = earliestStart.addingTimeInterval(spacing)
+        return delay
+    }
+}

--- a/scoremyday2Tests/FloatingDeltaQueueTests.swift
+++ b/scoremyday2Tests/FloatingDeltaQueueTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import scoremyday2
+
+final class FloatingDeltaQueueTests: XCTestCase {
+    func testSpacingBetweenRapidEventsIsWithinLimit() {
+        var queue = FloatingDeltaQueue(spacing: 0.08)
+        let base = Date(timeIntervalSince1970: 0)
+        let requestTimes = [0.0, 0.01, 0.02].map { base.addingTimeInterval($0) }
+
+        var scheduled: [TimeInterval] = []
+        for request in requestTimes {
+            let delay = queue.nextDelay(now: request)
+            scheduled.append(request.timeIntervalSince(base) + delay)
+        }
+
+        XCTAssertEqual(scheduled.count, 3)
+        XCTAssertLessThanOrEqual(scheduled[1] - scheduled[0], 0.1, "Events should start within 100ms of one another")
+        XCTAssertLessThanOrEqual(scheduled[2] - scheduled[1], 0.1, "Events should start within 100ms of one another")
+
+        // After a longer pause the queue should reset and emit immediately.
+        let later = base.addingTimeInterval(1.0)
+        let finalDelay = queue.nextDelay(now: later)
+        XCTAssertEqual(finalDelay, 0, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- animate floating score deltas along an arcing path and pulse the header when they land
- queue rapid-fire score updates with a lightweight scheduler to stagger animations
- add a unit test that verifies the queue spacing logic stays within the 100ms window

## Testing
- not run (Xcode is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4991f147c8331b774ae2a22a43b14