### PR TITLE
Improve stats UX with interactive contributions

### DIFF
--- a/scoremyday2/Services/AppEnvironment.swift
+++ b/scoremyday2/Services/AppEnvironment.swift
@@ -3,6 +3,7 @@ import Combine
 
 final class AppEnvironment: ObservableObject {
     @Published var settings = AppSettings()
+    @Published var selectedTab: RootTab = .deeds
     let persistenceController: PersistenceController
     private var cancellables: Set<AnyCancellable> = []
 

--- a/scoremyday2/UI/Pages/RootView.swift
+++ b/scoremyday2/UI/Pages/RootView.swift
@@ -8,21 +8,27 @@ struct RootView: View {
             LiquidBackgroundView()
                 .ignoresSafeArea()
 
-            TabView {
+            TabView(selection: Binding(
+                get: { appEnvironment.selectedTab },
+                set: { appEnvironment.selectedTab = $0 }
+            )) {
                 DeedsPage()
                     .tabItem {
                         Label("Deeds", systemImage: "square.grid.3x3")
                     }
+                    .tag(RootTab.deeds)
 
                 StatsPage()
                     .tabItem {
                         Label("Stats", systemImage: "chart.xyaxis.line")
                     }
+                    .tag(RootTab.stats)
 
                 SettingsPage()
                     .tabItem {
                         Label("Settings", systemImage: "gearshape")
                     }
+                    .tag(RootTab.settings)
             }
         }
         .glassBackground(

--- a/scoremyday2/Utilities/RootTab.swift
+++ b/scoremyday2/Utilities/RootTab.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum RootTab: Hashable {
+    case deeds
+    case stats
+    case settings
+}


### PR DESCRIPTION
## Summary
- add a shared root tab enum so the environment can drive navigation between tabs
- revamp the stats page with an empty state, accentuated card chips, and interactive contribution charts
- allow tapping contribution slices or legend rows to focus the per-card trend, and show absolute totals in the legend

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4b4f5ec588331a4a21a2e0995bc8a