### PR TITLE
Add comprehensive settings management

### DIFF
--- a/scoremyday2/Models/AppSettings.swift
+++ b/scoremyday2/Models/AppSettings.swift
@@ -4,5 +4,5 @@ struct AppSettings: Equatable {
     var dayCutoffHour: Int = 4
     var hapticsEnabled: Bool = true
     var soundsEnabled: Bool = true
-    var accentColorIdentifier: String = "default"
+    var accentColorHex: String?
 }

--- a/scoremyday2/Models/DeedModels.swift
+++ b/scoremyday2/Models/DeedModels.swift
@@ -92,19 +92,19 @@ struct AppPrefs: Identifiable, Equatable {
     var dayCutoffHour: Int
     var hapticsOn: Bool
     var soundsOn: Bool
-    var themeAccent: String?
+    var accentColorHex: String?
 
     init(
         id: UUID = UUID(),
         dayCutoffHour: Int = 4,
         hapticsOn: Bool = true,
         soundsOn: Bool = true,
-        themeAccent: String? = nil
+        accentColorHex: String? = nil
     ) {
         self.id = id
         self.dayCutoffHour = dayCutoffHour
         self.hapticsOn = hapticsOn
         self.soundsOn = soundsOn
-        self.themeAccent = themeAccent
+        self.accentColorHex = accentColorHex
     }
 }

--- a/scoremyday2/Persistence/Mappings.swift
+++ b/scoremyday2/Persistence/Mappings.swift
@@ -79,7 +79,7 @@ extension AppPrefs {
             dayCutoffHour: Int(managedObject.dayCutoffHour),
             hapticsOn: managedObject.hapticsOn,
             soundsOn: managedObject.soundsOn,
-            themeAccent: managedObject.themeAccent
+            accentColorHex: managedObject.themeAccent
         )
     }
 }
@@ -90,7 +90,7 @@ extension AppPrefsMO {
         dayCutoffHour = Int16(prefs.dayCutoffHour)
         hapticsOn = prefs.hapticsOn
         soundsOn = prefs.soundsOn
-        themeAccent = prefs.themeAccent
+        themeAccent = prefs.accentColorHex
     }
 }
 

--- a/scoremyday2/Services/AccountStore.swift
+++ b/scoremyday2/Services/AccountStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@MainActor
+final class AccountStore: ObservableObject {
+    struct Account {
+        let identifier: String
+        let email: String?
+    }
+
+    static let shared = AccountStore()
+
+    @Published private(set) var account: Account?
+
+    private let defaults: UserDefaults
+    private let identifierKey = "account.appleIdentifier"
+    private let emailKey = "account.appleEmail"
+
+    init(userDefaults: UserDefaults = .standard) {
+        defaults = userDefaults
+        if let identifier = defaults.string(forKey: identifierKey) {
+            let email = defaults.string(forKey: emailKey)
+            account = Account(identifier: identifier, email: email)
+        }
+    }
+
+    var displayName: String? {
+        account?.email ?? account?.identifier
+    }
+
+    func update(identifier: String, email: String?) {
+        account = Account(identifier: identifier, email: email ?? account?.email)
+        defaults.set(identifier, forKey: identifierKey)
+        if let email = email ?? account?.email {
+            defaults.set(email, forKey: emailKey)
+        } else {
+            defaults.removeObject(forKey: emailKey)
+        }
+    }
+
+    func signOut() {
+        account = nil
+        defaults.removeObject(forKey: identifierKey)
+        defaults.removeObject(forKey: emailKey)
+    }
+}

--- a/scoremyday2/Services/AppPrefsStore.swift
+++ b/scoremyday2/Services/AppPrefsStore.swift
@@ -1,8 +1,75 @@
 import Combine
+import Foundation
 
-/// Replace this with your real AppPrefs Core Data binding. This stub unblocks compilation.
+@MainActor
 final class AppPrefsStore: ObservableObject {
     static let shared = AppPrefsStore()
-    @Published var hapticsOn: Bool = true
-    @Published var soundsOn: Bool = true
+
+    @Published var dayCutoffHour: Int
+    @Published var hapticsOn: Bool
+    @Published var soundsOn: Bool
+    @Published var accentColorHex: String?
+
+    private let repository: AppPrefsRepository
+    private var prefsID: UUID
+    private var cancellables: Set<AnyCancellable> = []
+    private var isPersisting = false
+
+    init(persistenceController: PersistenceController = .shared) {
+        let context = persistenceController.viewContext
+        repository = AppPrefsRepository(context: context)
+
+        let storedPrefs = (try? repository.fetch()) ?? AppPrefs()
+        prefsID = storedPrefs.id
+        dayCutoffHour = storedPrefs.dayCutoffHour
+        hapticsOn = storedPrefs.hapticsOn
+        soundsOn = storedPrefs.soundsOn
+        accentColorHex = storedPrefs.accentColorHex
+
+        bindPersistence()
+    }
+
+    private func bindPersistence() {
+        $dayCutoffHour
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.persistChanges() }
+            .store(in: &cancellables)
+
+        $hapticsOn
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.persistChanges() }
+            .store(in: &cancellables)
+
+        $soundsOn
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.persistChanges() }
+            .store(in: &cancellables)
+
+        $accentColorHex
+            .dropFirst()
+            .removeDuplicates(by: { $0 == $1 })
+            .sink { [weak self] _ in self?.persistChanges() }
+            .store(in: &cancellables)
+    }
+
+    private func persistChanges() {
+        guard !isPersisting else { return }
+        isPersisting = true
+        let prefs = AppPrefs(
+            id: prefsID,
+            dayCutoffHour: dayCutoffHour,
+            hapticsOn: hapticsOn,
+            soundsOn: soundsOn,
+            accentColorHex: accentColorHex
+        )
+        do {
+            try repository.update(prefs)
+        } catch {
+            print("Failed to persist app prefs: \(error)")
+        }
+        isPersisting = false
+    }
 }

--- a/scoremyday2/Services/DataExportService.swift
+++ b/scoremyday2/Services/DataExportService.swift
@@ -1,0 +1,217 @@
+import CoreData
+import Foundation
+
+struct DataExportService {
+    private let deedsRepository: DeedsRepository
+    private let entriesRepository: EntriesRepository
+
+    init(persistenceController: PersistenceController = .shared) {
+        let context = persistenceController.viewContext
+        deedsRepository = DeedsRepository(context: context)
+        entriesRepository = EntriesRepository(context: context)
+    }
+
+    func makeJSONExport() throws -> [String: Data] {
+        let cards = try deedsRepository.fetchAll(includeArchived: true)
+        let entries = try entriesRepository.fetchEntries()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        let cardsData = try encoder.encode(cards.map { ExportableCard(card: $0) })
+        let entriesData = try encoder.encode(entries.map { ExportableEntry(entry: $0) })
+
+        return [
+            "deed-cards.json": cardsData,
+            "deed-entries.json": entriesData
+        ]
+    }
+
+    func makeCSVExport() throws -> [String: Data] {
+        let cards = try deedsRepository.fetchAll(includeArchived: true)
+        let entries = try entriesRepository.fetchEntries()
+
+        let cardsCSV = csvString(rows: cards.map { ExportableCard(card: $0, formatter: Self.doubleFormatter) }.map { $0.csvRow }, headers: ExportableCard.csvHeaders)
+        let entriesCSV = csvString(rows: entries.map { ExportableEntry(entry: $0, formatter: Self.doubleFormatter) }.map { $0.csvRow }, headers: ExportableEntry.csvHeaders)
+
+        return [
+            "deed-cards.csv": Data(cardsCSV.utf8),
+            "deed-entries.csv": Data(entriesCSV.utf8)
+        ]
+    }
+
+    private func csvString(rows: [[String]], headers: [String]) -> String {
+        var lines: [String] = []
+        lines.append(headers.joined(separator: ","))
+        for row in rows {
+            lines.append(row.map(Self.escapeForCSV).joined(separator: ","))
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func escapeForCSV(_ value: String) -> String {
+        let needsEscaping = value.contains(",") || value.contains("\n") || value.contains("\"")
+        let escaped = value.replacingOccurrences(of: "\"", with: "\"\"")
+        return needsEscaping ? "\"\(escaped)\"" : escaped
+    }
+
+    private static let doubleFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 6
+        formatter.minimumFractionDigits = 0
+        formatter.usesGroupingSeparator = false
+        return formatter
+    }()
+}
+
+private extension DataExportService {
+    struct ExportableCard: Codable {
+        let id: UUID
+        let name: String
+        let emoji: String
+        let colorHex: String
+        let category: String
+        let polarity: String
+        let unitType: String
+        let unitLabel: String
+        let pointsPerUnit: Double
+        let dailyCap: Double?
+        let isPrivate: Bool
+        let showOnStats: Bool
+        let createdAt: Date
+        let isArchived: Bool
+
+        private let formatter: NumberFormatter
+
+        init(card: DeedCard, formatter: NumberFormatter = DataExportService.doubleFormatter) {
+            id = card.id
+            name = card.name
+            emoji = card.emoji
+            colorHex = card.colorHex
+            category = card.category
+            polarity = card.polarity == .positive ? "positive" : "negative"
+            unitType = String(describing: card.unitType)
+            unitLabel = card.unitLabel
+            pointsPerUnit = card.pointsPerUnit
+            dailyCap = card.dailyCap
+            isPrivate = card.isPrivate
+            showOnStats = card.showOnStats
+            createdAt = card.createdAt
+            isArchived = card.isArchived
+            self.formatter = formatter
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case emoji
+            case colorHex
+            case category
+            case polarity
+            case unitType
+            case unitLabel
+            case pointsPerUnit
+            case dailyCap
+            case isPrivate
+            case showOnStats
+            case createdAt
+            case isArchived
+        }
+
+        var csvRow: [String] {
+            [
+                id.uuidString,
+                name,
+                emoji,
+                colorHex,
+                category,
+                polarity,
+                unitType,
+                unitLabel,
+                formatter.string(from: NSNumber(value: pointsPerUnit)) ?? String(pointsPerUnit),
+                dailyCap.flatMap { formatter.string(from: NSNumber(value: $0)) } ?? "",
+                String(isPrivate),
+                String(showOnStats),
+                ISO8601DateFormatter.exportFormatter.string(from: createdAt),
+                String(isArchived)
+            ]
+        }
+
+        static let csvHeaders = [
+            "id",
+            "name",
+            "emoji",
+            "colorHex",
+            "category",
+            "polarity",
+            "unitType",
+            "unitLabel",
+            "pointsPerUnit",
+            "dailyCap",
+            "isPrivate",
+            "showOnStats",
+            "createdAt",
+            "isArchived"
+        ]
+    }
+
+    struct ExportableEntry: Codable {
+        let id: UUID
+        let deedId: UUID
+        let timestamp: Date
+        let amount: Double
+        let computedPoints: Double
+        let note: String?
+
+        private let formatter: NumberFormatter
+
+        init(entry: DeedEntry, formatter: NumberFormatter = DataExportService.doubleFormatter) {
+            id = entry.id
+            deedId = entry.deedId
+            timestamp = entry.timestamp
+            amount = entry.amount
+            computedPoints = entry.computedPoints
+            note = entry.note
+            self.formatter = formatter
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case deedId
+            case timestamp
+            case amount
+            case computedPoints
+            case note
+        }
+
+        var csvRow: [String] {
+            [
+                id.uuidString,
+                deedId.uuidString,
+                ISO8601DateFormatter.exportFormatter.string(from: timestamp),
+                formatter.string(from: NSNumber(value: amount)) ?? String(amount),
+                formatter.string(from: NSNumber(value: computedPoints)) ?? String(computedPoints),
+                note ?? ""
+            ]
+        }
+
+        static let csvHeaders = [
+            "id",
+            "deedId",
+            "timestamp",
+            "amount",
+            "computedPoints",
+            "note"
+        ]
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let exportFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/scoremyday2/Services/DemoDataService.swift
+++ b/scoremyday2/Services/DemoDataService.swift
@@ -53,6 +53,12 @@ struct DemoDataService {
         }
     }
 
+    func resetAllData() throws {
+        try clearExistingData()
+        try prefsRepository.update(AppPrefs())
+        _ = try InitialDataSeeder(context: context).seedDefaultDeedCards()
+    }
+
     private func clearExistingData() throws {
         try context.performAndReturn {
             let entryRequest = DeedEntryMO.fetchRequest()

--- a/scoremyday2/UI/Pages/DeedsPage.swift
+++ b/scoremyday2/UI/Pages/DeedsPage.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 
 struct DeedsPage: View {
+    @EnvironmentObject private var appEnvironment: AppEnvironment
     @StateObject private var viewModel = DeedsPageViewModel()
 
     @State private var quickAddState: QuickAddState?
@@ -51,6 +52,12 @@ struct DeedsPage: View {
             }
         }
         .onAppear { viewModel.onAppear() }
+        .onChange(of: appEnvironment.settings.dayCutoffHour) { newValue in
+            viewModel.updateCutoffHour(newValue)
+        }
+        .onChange(of: appEnvironment.dataVersion) { _ in
+            viewModel.reload()
+        }
         .sheet(item: $quickAddState) { state in
             QuickAddSheet(state: state, onSave: { updated in
                 if let entry = viewModel.log(cardID: updated.card.id, amount: updated.amount, note: updated.note.isEmpty ? nil : updated.note) {

--- a/scoremyday2/UI/Pages/DeedsPageViewModel.swift
+++ b/scoremyday2/UI/Pages/DeedsPageViewModel.swift
@@ -97,6 +97,18 @@ final class DeedsPageViewModel: ObservableObject {
         }
     }
 
+    func updateCutoffHour(_ hour: Int) {
+        guard cutoffHour != hour else { return }
+        cutoffHour = hour
+
+        do {
+            todayNetScore = try computeTodayScore()
+            sparklineValues = try computeSparkline()
+        } catch {
+            assertionFailure("Failed to recompute metrics: \(error)")
+        }
+    }
+
     func upsert(card: DeedCard) {
         do {
             try deedsRepository.upsert(card)

--- a/scoremyday2/UI/Pages/RootView.swift
+++ b/scoremyday2/UI/Pages/RootView.swift
@@ -33,10 +33,18 @@ struct RootView: View {
         }
         .glassBackground(
             cornerRadius: 0,
-            tint: Color(appEnvironment.settings.accentColorIdentifier),
+            tint: accentColor,
             warpStrength: 2
         )
-        .accentColor(Color(appEnvironment.settings.accentColorIdentifier))
+        .accentColor(accentColor)
+    }
+
+    private var accentColor: Color {
+        if let hex = appEnvironment.settings.accentColorHex, !hex.isEmpty {
+            return Color(hex: hex, fallback: .accentColor)
+        } else {
+            return .accentColor
+        }
     }
 }
 

--- a/scoremyday2/UI/Pages/SettingsPage.swift
+++ b/scoremyday2/UI/Pages/SettingsPage.swift
@@ -1,72 +1,408 @@
+import AuthenticationServices
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SettingsPage: View {
     @EnvironmentObject private var appEnvironment: AppEnvironment
     @ObservedObject private var prefs = AppPrefsStore.shared
+    @ObservedObject private var accountStore = AccountStore.shared
+
+    @State private var dayCutoffSelection = SettingsPage.makeDate(forHour: AppPrefsStore.shared.dayCutoffHour)
     @State private var isLoadingDemoData = false
-    @State private var demoDataError: String?
+    @State private var isResettingData = false
+    @State private var showResetConfirmation = false
+    @State private var actionError: String?
+    @State private var jsonExportDocument: FolderExportDocument?
+    @State private var csvExportDocument: FolderExportDocument?
+    @State private var isPresentingJSONExporter = false
+    @State private var isPresentingCSVExporter = false
+    @State private var isPreparingJSONExport = false
+    @State private var isPreparingCSVExport = false
+
+    private let shareURL = URL(string: "https://apps.apple.com/app/id0000000000")!
 
     var body: some View {
         NavigationStack {
             List {
-                Section("Preferences") {
-                    Toggle("Haptics", isOn: $prefs.hapticsOn)
-                    Toggle("Sounds", isOn: $prefs.soundsOn)
-                }
-
-                Section("QA") {
-                    Toggle(isOn: Binding(
-                        get: { false },
-                        set: { newValue in
-                            guard newValue else { return }
-                            loadDemoData()
-                        }
-                    )) {
-                        HStack {
-                            Text("Load Demo Data")
-                            if isLoadingDemoData {
-                                Spacer()
-                                ProgressView()
-                            }
-                        }
-                    }
-                    .disabled(isLoadingDemoData)
-                }
+                accountSection
+                preferencesSection
+                dataSection
+                shareSection
+                aboutSection
             }
             .navigationTitle("Settings")
             .onAppear {
                 SoundManager.shared.preload()
             }
-            .alert("Unable to Load Demo Data", isPresented: Binding(
-                get: { demoDataError != nil },
-                set: { isPresented in
-                    if !isPresented {
-                        demoDataError = nil
+            .onChange(of: prefs.dayCutoffHour) { newValue in
+                let newDate = SettingsPage.makeDate(forHour: newValue)
+                if Calendar.current.component(.hour, from: dayCutoffSelection) != newValue {
+                    dayCutoffSelection = newDate
+                }
+            }
+            .alert("Something went wrong", isPresented: Binding(
+                get: { actionError != nil },
+                set: { newValue in
+                    if !newValue {
+                        actionError = nil
                     }
                 }
             )) {
                 Button("OK", role: .cancel) { }
             } message: {
-                Text(demoDataError ?? "")
+                Text(actionError ?? "")
+            }
+            .confirmationDialog(
+                "Reset All Data?",
+                isPresented: $showResetConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Reset All Data", role: .destructive) {
+                    resetAllData()
+                }
+            } message: {
+                Text("This deletes all deeds, entries, and preferences. This action cannot be undone.")
+            }
+            .fileExporter(
+                isPresented: $isPresentingJSONExporter,
+                document: jsonExportDocument,
+                contentType: .folder,
+                defaultFilename: "ScoreMyDay-JSON-Export"
+            ) { result in
+                if case .failure(let error) = result {
+                    actionError = error.localizedDescription
+                }
+                jsonExportDocument = nil
+            }
+            .fileExporter(
+                isPresented: $isPresentingCSVExporter,
+                document: csvExportDocument,
+                contentType: .folder,
+                defaultFilename: "ScoreMyDay-CSV-Export"
+            ) { result in
+                if case .failure(let error) = result {
+                    actionError = error.localizedDescription
+                }
+                csvExportDocument = nil
             }
         }
+    }
+
+    private var accountSection: some View {
+        Section("Account") {
+            if let displayName = accountStore.displayName {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label(displayName, systemImage: "applelogo")
+                        .font(.headline)
+                    Text("Sync coming soon.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+
+                Button("Sign Out", role: .destructive) {
+                    accountStore.signOut()
+                }
+            } else {
+                SignInWithAppleButton(.signIn) { request in
+                    request.requestedScopes = [.email, .fullName]
+                } onCompletion: { result in
+                    switch result {
+                    case .success(let authorization):
+                        handleAppleAuthorization(authorization)
+                    case .failure(let error):
+                        actionError = error.localizedDescription
+                    }
+                }
+                .signInWithAppleButtonStyle(.black)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .center)
+            }
+        }
+    }
+
+    private var preferencesSection: some View {
+        Section("Preferences") {
+            DatePicker(
+                "Day Cutoff",
+                selection: $dayCutoffSelection,
+                displayedComponents: [.hourAndMinute]
+            )
+            .datePickerStyle(.wheel)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onChange(of: dayCutoffSelection) { newValue in
+                updateDayCutoff(with: newValue)
+            }
+
+            Toggle("Haptics", isOn: $prefs.hapticsOn)
+            Toggle("Sounds", isOn: $prefs.soundsOn)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Accent Color")
+                    .font(.subheadline.weight(.semibold))
+                accentPalette
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    private var dataSection: some View {
+        Section("Data") {
+            Button {
+                prepareJSONExport()
+            } label: {
+                HStack {
+                    Label("Export JSON", systemImage: "doc.zipper")
+                    Spacer()
+                    if isPreparingJSONExport {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isPreparingJSONExport)
+
+            Button {
+                prepareCSVExport()
+            } label: {
+                HStack {
+                    Label("Export CSV", systemImage: "tablecells")
+                    Spacer()
+                    if isPreparingCSVExport {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isPreparingCSVExport)
+
+            Button {
+                loadDemoData()
+            } label: {
+                HStack {
+                    Label("Load Demo Data", systemImage: "sparkles")
+                    Spacer()
+                    if isLoadingDemoData {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isLoadingDemoData || isResettingData)
+
+            Button(role: .destructive) {
+                showResetConfirmation = true
+            } label: {
+                HStack {
+                    Label("Reset All Data", systemImage: "trash")
+                    Spacer()
+                    if isResettingData {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isResettingData || isLoadingDemoData)
+        }
+    }
+
+    private var shareSection: some View {
+        Section("Share") {
+            ShareLink(
+                item: shareURL,
+                subject: Text("ScoreMyDay"),
+                message: Text("I’ve been tracking my deeds with ScoreMyDay. Check it out!")
+            ) {
+                Label("Share ScoreMyDay", systemImage: "square.and.arrow.up")
+            }
+        }
+    }
+
+    private var aboutSection: some View {
+        Section("About") {
+            HStack {
+                Text("Version")
+                Spacer()
+                Text(Self.versionString)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var accentPalette: some View {
+        let columns = [GridItem(.adaptive(minimum: 48, maximum: 64), spacing: 12)]
+        return LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+            ForEach(AccentColorOption.allOptions) { option in
+                Button {
+                    prefs.accentColorHex = option.hex
+                } label: {
+                    Circle()
+                        .fill(option.color)
+                        .frame(width: 44, height: 44)
+                        .overlay(
+                            Circle()
+                                .strokeBorder(option.isSelected(with: prefs.accentColorHex) ? Color.primary.opacity(0.8) : .clear, lineWidth: 3)
+                        )
+                        .overlay {
+                            if option.isSystem {
+                                Image(systemName: "sparkles")
+                                    .foregroundStyle(.white.opacity(0.9))
+                            }
+                        }
+                        .overlay(alignment: .bottomTrailing) {
+                            if option.isSelected(with: prefs.accentColorHex) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .font(.system(size: 18, weight: .bold))
+                                    .foregroundStyle(Color.white)
+                                    .shadow(radius: 1)
+                                    .offset(x: -2, y: -2)
+                            }
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(option.name)
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    private func handleAppleAuthorization(_ authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            actionError = "Unable to read Apple ID credentials."
+            return
+        }
+
+        let identifier = credential.user
+        let email = credential.email ?? accountStore.account?.email
+        accountStore.update(identifier: identifier, email: email)
+    }
+
+    private func updateDayCutoff(with date: Date) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone.current
+        let hour = calendar.component(.hour, from: date)
+        if prefs.dayCutoffHour != hour {
+            prefs.dayCutoffHour = hour
+        }
+
+        if calendar.component(.minute, from: date) != 0 || calendar.component(.second, from: date) != 0 {
+            if let normalized = calendar.date(bySettingHour: hour, minute: 0, second: 0, of: date) {
+                dayCutoffSelection = normalized
+            }
+        }
+    }
+
+    private func prepareJSONExport() {
+        guard !isPreparingJSONExport else { return }
+        isPreparingJSONExport = true
+        do {
+            let service = DataExportService(persistenceController: appEnvironment.persistenceController)
+            let files = try service.makeJSONExport()
+            jsonExportDocument = FolderExportDocument(items: files)
+            isPresentingJSONExporter = true
+        } catch {
+            actionError = error.localizedDescription
+        }
+        isPreparingJSONExport = false
+    }
+
+    private func prepareCSVExport() {
+        guard !isPreparingCSVExport else { return }
+        isPreparingCSVExport = true
+        do {
+            let service = DataExportService(persistenceController: appEnvironment.persistenceController)
+            let files = try service.makeCSVExport()
+            csvExportDocument = FolderExportDocument(items: files)
+            isPresentingCSVExporter = true
+        } catch {
+            actionError = error.localizedDescription
+        }
+        isPreparingCSVExport = false
     }
 
     private func loadDemoData() {
-        guard !isLoadingDemoData else { return }
+        guard !isLoadingDemoData && !isResettingData else { return }
         isLoadingDemoData = true
 
-        Task { @MainActor in
-            defer { isLoadingDemoData = false }
-
+        Task {
             do {
                 let service = DemoDataService(persistenceController: appEnvironment.persistenceController)
                 try service.loadDemoData()
+                await MainActor.run {
+                    isLoadingDemoData = false
+                    appEnvironment.notifyDataDidChange()
+                }
             } catch {
-                demoDataError = error.localizedDescription
+                await MainActor.run {
+                    isLoadingDemoData = false
+                    actionError = error.localizedDescription
+                }
             }
         }
     }
+
+    private func resetAllData() {
+        guard !isResettingData && !isLoadingDemoData else { return }
+        isResettingData = true
+
+        Task {
+            do {
+                let service = DemoDataService(persistenceController: appEnvironment.persistenceController)
+                try service.resetAllData()
+                await MainActor.run {
+                    prefs.dayCutoffHour = 4
+                    prefs.hapticsOn = true
+                    prefs.soundsOn = true
+                    prefs.accentColorHex = nil
+                    isResettingData = false
+                    appEnvironment.notifyDataDidChange()
+                }
+            } catch {
+                await MainActor.run {
+                    isResettingData = false
+                    actionError = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private static func makeDate(forHour hour: Int) -> Date {
+        var calendar = Calendar.current
+        calendar.timeZone = TimeZone.current
+        let now = Date()
+        var components = calendar.dateComponents([.year, .month, .day], from: now)
+        components.hour = hour
+        components.minute = 0
+        return calendar.date(from: components) ?? now
+    }
+
+    private static var versionString: String {
+        let bundle = Bundle.main
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "–"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "–"
+        return "\(version) (\(build))"
+    }
+}
+
+private struct AccentColorOption: Identifiable {
+    let id: String
+    let name: String
+    let hex: String?
+
+    var color: Color {
+        if let hex { return Color(hex: hex, fallback: .accentColor) }
+        return .accentColor
+    }
+
+    var isSystem: Bool { hex == nil }
+
+    func isSelected(with currentHex: String?) -> Bool {
+        currentHex == hex
+    }
+
+    static let allOptions: [AccentColorOption] = [
+        AccentColorOption(id: "system", name: "System", hex: nil),
+        AccentColorOption(id: "sunrise", name: "Sunrise", hex: "#FF9F0A"),
+        AccentColorOption(id: "ocean", name: "Ocean", hex: "#0A84FF"),
+        AccentColorOption(id: "forest", name: "Forest", hex: "#34C759"),
+        AccentColorOption(id: "lavender", name: "Lavender", hex: "#AF52DE"),
+        AccentColorOption(id: "rose", name: "Rose", hex: "#FF375F")
+    ]
 }
 
 #Preview {

--- a/scoremyday2/UI/Pages/StatsPage.swift
+++ b/scoremyday2/UI/Pages/StatsPage.swift
@@ -45,6 +45,9 @@ struct StatsPage: View {
         .onChange(of: appEnvironment.settings.dayCutoffHour) { newValue in
             Task { await viewModel.updateCutoffHour(newValue) }
         }
+        .onChange(of: appEnvironment.dataVersion) { _ in
+            Task { await viewModel.forceReload() }
+        }
     }
 
     private var emptyStateView: some View {
@@ -512,6 +515,10 @@ final class StatsPageViewModel: ObservableObject {
         guard hour != cutoffHour else { return }
         cutoffHour = hour
         // Re-ingest entries to respect the new cutoff boundaries.
+        await reloadData()
+    }
+
+    func forceReload() async {
         await reloadData()
     }
 

--- a/scoremyday2/UI/Utilities/FolderExportDocument.swift
+++ b/scoremyday2/UI/Utilities/FolderExportDocument.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FolderExportDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.folder] }
+
+    var items: [String: Data]
+
+    init(items: [String: Data]) {
+        self.items = items
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        items = [:]
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        let wrappers = items.mapValues { FileWrapper(regularFileWithContents: $0) }
+        return FileWrapper(directoryWithFileWrappers: wrappers)
+    }
+}


### PR DESCRIPTION
## Summary
- overhaul the Settings page with account, preference, data, share, and about sections including Sign in with Apple, day cutoff picker, haptic/sound toggles, accent palette, and app metadata
- add data export, demo data reload, and destructive reset flows with Core Data seeding plus share link messaging
- extend preference and environment stores to persist day cutoff and accent color, notify other views, and refresh metrics immediately when the cutoff changes

## Testing
- Not run (iOS tooling unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e4e01215a48331ac51c4f6e90dcecb