### PR TITLE
Ensure new deed cards float to the top

### DIFF
--- a/scoremyday2Tests/DeedsPageViewModelTests.swift
+++ b/scoremyday2Tests/DeedsPageViewModelTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import scoremyday2
+
+@MainActor
+final class DeedsPageViewModelTests: XCTestCase {
+    func testNewCardAppearsFirstBeforeLogging() throws {
+        let persistence = PersistenceController(inMemory: true)
+        let viewModel = DeedsPageViewModel(persistenceController: persistence)
+
+        viewModel.reload()
+
+        let newCard = DeedCard(
+            name: "Regression Card",
+            emoji: "🧪",
+            colorHex: "#FFFFFF",
+            category: "Testing",
+            polarity: .positive,
+            unitType: .count,
+            unitLabel: "time",
+            pointsPerUnit: 1,
+            dailyCap: nil,
+            isPrivate: false,
+            createdAt: Date().addingTimeInterval(5)
+        )
+
+        viewModel.upsert(card: newCard)
+
+        XCTAssertEqual(viewModel.cards.first?.id, newCard.id)
+
+        viewModel.reload()
+
+        XCTAssertEqual(viewModel.cards.first?.id, newCard.id)
+    }
+}


### PR DESCRIPTION
## Summary
- update the deeds page sorting logic to treat newly created cards as most recently used
- ensure resorting remains deterministic by falling back to card names and IDs when dates match
- add a regression view-model test that asserts a new card is surfaced to the top before any logging occurs

## Testing
- swift test *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68e5090b900c8331b1b92b507eb152c6