### PR TITLE
Preserve preferences when resetting demo data

### DIFF
--- a/scoremyday2.xcodeproj/project.pbxproj
+++ b/scoremyday2.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
                 9F4D72EC7CF4442DAD0B12B1 /* AppDayRangeTests.swift in Sources */ = {isa = PBXBuildFile; file = 39F5DF71227A4AFE9E8E7B3D /* AppDayRangeTests.swift */; };
                 BD136B4E922740EC92644730 /* EntriesRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; file = F7972FDA75924E0CB688140B /* EntriesRepositoryTests.swift */; };
+                A7B64E0B5E394A669C6E7F2B /* DemoDataServiceTests.swift in Sources */ = {isa = PBXBuildFile; file = A7B64E0A5E394A669C6E7F2B /* DemoDataServiceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -16,6 +17,7 @@
                 0EA3727FF57848ACB86820FA /* scoremyday2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = scoremyday2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
                 39F5DF71227A4AFE9E8E7B3D /* AppDayRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDayRangeTests.swift; sourceTree = "<group>"; };
                 F7972FDA75924E0CB688140B /* EntriesRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntriesRepositoryTests.swift; sourceTree = "<group>"; };
+                A7B64E0A5E394A669C6E7F2B /* DemoDataServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoDataServiceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -90,6 +92,7 @@
                         children = (
                                 39F5DF71227A4AFE9E8E7B3D /* AppDayRangeTests.swift */,
                                 F7972FDA75924E0CB688140B /* EntriesRepositoryTests.swift */,
+                                A7B64E0A5E394A669C6E7F2B /* DemoDataServiceTests.swift */,
                         );
                         path = scoremyday2Tests;
                         sourceTree = "<group>";
@@ -237,6 +240,7 @@
                         files = (
                                 9F4D72EC7CF4442DAD0B12B1 /* AppDayRangeTests.swift in Sources */,
                                 BD136B4E922740EC92644730 /* EntriesRepositoryTests.swift in Sources */,
+                                A7B64E0B5E394A669C6E7F2B /* DemoDataServiceTests.swift in Sources */,
                         );
                         runOnlyForDeploymentPostprocessing = 0;
                 };

--- a/scoremyday2/Services/DemoDataService.swift
+++ b/scoremyday2/Services/DemoDataService.swift
@@ -55,7 +55,6 @@ struct DemoDataService {
 
     func resetAllData() throws {
         try clearExistingData()
-        try prefsRepository.update(AppPrefs())
         _ = try InitialDataSeeder(context: context).seedDefaultDeedCards()
     }
 

--- a/scoremyday2/UI/Pages/SettingsPage.swift
+++ b/scoremyday2/UI/Pages/SettingsPage.swift
@@ -61,7 +61,7 @@ struct SettingsPage: View {
                     resetAllData()
                 }
             } message: {
-                Text("This deletes all deeds, entries, and preferences. This action cannot be undone.")
+                Text("This deletes all deeds and entries. Preferences remain unchanged. This action cannot be undone.")
             }
             .fileExporter(
                 isPresented: $isPresentingJSONExporter,
@@ -338,6 +338,12 @@ struct SettingsPage: View {
 
     private func resetAllData() {
         guard !isResettingData && !isLoadingDemoData else { return }
+        let storedPrefs = (
+            dayCutoffHour: prefs.dayCutoffHour,
+            hapticsOn: prefs.hapticsOn,
+            soundsOn: prefs.soundsOn,
+            accentColorHex: prefs.accentColorHex
+        )
         isResettingData = true
 
         Task {
@@ -345,10 +351,19 @@ struct SettingsPage: View {
                 let service = DemoDataService(persistenceController: appEnvironment.persistenceController)
                 try service.resetAllData()
                 await MainActor.run {
-                    prefs.dayCutoffHour = 4
-                    prefs.hapticsOn = true
-                    prefs.soundsOn = true
-                    prefs.accentColorHex = nil
+                    if prefs.dayCutoffHour != storedPrefs.dayCutoffHour {
+                        prefs.dayCutoffHour = storedPrefs.dayCutoffHour
+                    }
+                    if prefs.hapticsOn != storedPrefs.hapticsOn {
+                        prefs.hapticsOn = storedPrefs.hapticsOn
+                    }
+                    if prefs.soundsOn != storedPrefs.soundsOn {
+                        prefs.soundsOn = storedPrefs.soundsOn
+                    }
+                    if prefs.accentColorHex != storedPrefs.accentColorHex {
+                        prefs.accentColorHex = storedPrefs.accentColorHex
+                    }
+                    dayCutoffSelection = SettingsPage.makeDate(forHour: storedPrefs.dayCutoffHour)
                     isResettingData = false
                     appEnvironment.notifyDataDidChange()
                 }

--- a/scoremyday2Tests/DemoDataServiceTests.swift
+++ b/scoremyday2Tests/DemoDataServiceTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import CoreData
+@testable import scoremyday2
+
+final class DemoDataServiceTests: XCTestCase {
+    var persistence: PersistenceController!
+    var prefsRepository: AppPrefsRepository!
+
+    override func setUpWithError() throws {
+        persistence = PersistenceController(inMemory: true)
+        prefsRepository = AppPrefsRepository(context: persistence.viewContext)
+    }
+
+    override func tearDownWithError() throws {
+        persistence = nil
+        prefsRepository = nil
+    }
+
+    func testResetAllDataPreservesExistingPreferences() throws {
+        var prefs = try prefsRepository.fetch()
+        prefs.dayCutoffHour = 9
+        prefs.hapticsOn = false
+        prefs.soundsOn = false
+        prefs.accentColorHex = "#123456"
+        try prefsRepository.update(prefs)
+
+        let service = DemoDataService(persistenceController: persistence)
+        try service.resetAllData()
+
+        let storedPrefs = try prefsRepository.fetch()
+        XCTAssertEqual(storedPrefs.dayCutoffHour, 9)
+        XCTAssertFalse(storedPrefs.hapticsOn)
+        XCTAssertFalse(storedPrefs.soundsOn)
+        XCTAssertEqual(storedPrefs.accentColorHex, "#123456")
+    }
+}


### PR DESCRIPTION
## Summary
- capture the current app preferences before resetting demo data and restore them afterwards
- stop DemoDataService from overwriting stored preferences and update the reset confirmation copy
- add a regression test ensuring Reset All Data keeps customized preferences intact

## Testing
- `xcodebuild test -project scoremyday2.xcodeproj -scheme scoremyday2 -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: `xcodebuild` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e509259220833197282c0cb28a4435