### PR TITLE
Add toast overlay for demo data loading

### DIFF
--- a/scoremyday2/Services/AppEnvironment.swift
+++ b/scoremyday2/Services/AppEnvironment.swift
@@ -1,13 +1,26 @@
-import Foundation
 import Combine
+import Foundation
 
 @MainActor
 final class AppEnvironment: ObservableObject {
+    struct Toast: Identifiable, Equatable {
+        let id = UUID()
+        let message: String
+        let iconSystemName: String?
+
+        init(message: String, iconSystemName: String? = nil) {
+            self.message = message
+            self.iconSystemName = iconSystemName
+        }
+    }
+
     @Published var settings = AppSettings()
     @Published var selectedTab: RootTab = .deeds
     @Published var dataVersion: Int = 0
+    @Published var toast: Toast?
     let persistenceController: PersistenceController
     private var cancellables: Set<AnyCancellable> = []
+    private var toastDismissTask: Task<Void, Never>?
 
     init(persistenceController: PersistenceController = .shared) {
         self.persistenceController = persistenceController
@@ -65,7 +78,49 @@ final class AppEnvironment: ObservableObject {
             .store(in: &cancellables)
     }
 
+    deinit {
+        toastDismissTask?.cancel()
+    }
+
     func notifyDataDidChange() {
         dataVersion &+= 1
+    }
+
+    func showToast(
+        message: String,
+        iconSystemName: String? = nil,
+        duration: TimeInterval = 2.5
+    ) {
+        toastDismissTask?.cancel()
+        toastDismissTask = nil
+
+        let newToast = Toast(message: message, iconSystemName: iconSystemName)
+        toast = newToast
+
+        guard duration > 0 else { return }
+
+        let nanoseconds = UInt64(max(0, duration) * 1_000_000_000)
+        toastDismissTask = Task { [weak self] in
+            guard nanoseconds > 0 else { return }
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self else { return }
+                if self.toast?.id == newToast.id {
+                    self.toast = nil
+                }
+            }
+        }
+    }
+
+    func hideToast(matching toastID: Toast.ID? = nil) {
+        guard let current = toast else { return }
+        if let toastID, toastID != current.id {
+            return
+        }
+
+        toastDismissTask?.cancel()
+        toastDismissTask = nil
+        toast = nil
     }
 }

--- a/scoremyday2/UI/Components/ToastOverlayView.swift
+++ b/scoremyday2/UI/Components/ToastOverlayView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct ToastOverlayView: View {
+    @EnvironmentObject private var appEnvironment: AppEnvironment
+
+    var body: some View {
+        GeometryReader { proxy in
+            VStack(spacing: 0) {
+                if let toast = appEnvironment.toast {
+                    ToastBannerView(toast: toast, tint: accentColor)
+                        .padding(.top, proxy.safeAreaInsets.top + 12)
+                        .padding(.horizontal, 20)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .accessibilityAddTraits(.isStaticText)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: appEnvironment.toast)
+    }
+
+    private var accentColor: Color {
+        if let hex = appEnvironment.settings.accentColorHex, !hex.isEmpty {
+            return Color(hex: hex, fallback: .accentColor)
+        } else {
+            return .accentColor
+        }
+    }
+}
+
+private struct ToastBannerView: View {
+    let toast: AppEnvironment.Toast
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if let icon = toast.iconSystemName {
+                Image(systemName: icon)
+                    .imageScale(.medium)
+                    .font(.system(size: 16, weight: .semibold))
+            }
+
+            Text(toast.message)
+                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .multilineTextAlignment(.leading)
+                .foregroundStyle(foregroundStyle)
+                .accessibilityLabel(toast.message)
+                .padding(.vertical, 2)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(background)
+        .shadow(color: Color.black.opacity(0.18), radius: 18, x: 0, y: 12)
+    }
+
+    private var background: some View {
+        RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .fill(.ultraThinMaterial)
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .strokeBorder(tint.opacity(0.35), lineWidth: 1.2)
+            )
+    }
+
+    private var foregroundStyle: some ShapeStyle {
+        Color.primary
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.opacity(0.3)
+            .ignoresSafeArea()
+
+        ToastOverlayView()
+            .environmentObject({
+                let environment = AppEnvironment()
+                environment.showToast(message: "Demo data loaded.")
+                return environment
+            }())
+    }
+}

--- a/scoremyday2/UI/Pages/RootView.swift
+++ b/scoremyday2/UI/Pages/RootView.swift
@@ -37,6 +37,9 @@ struct RootView: View {
             warpStrength: 2
         )
         .accentColor(accentColor)
+        .overlay(alignment: .top) {
+            ToastOverlayView()
+        }
     }
 
     private var accentColor: Color {

--- a/scoremyday2/UI/Pages/SettingsPage.swift
+++ b/scoremyday2/UI/Pages/SettingsPage.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct SettingsPage: View {
     @EnvironmentObject private var appEnvironment: AppEnvironment
+    @Environment(\.dismiss) private var dismiss
     @ObservedObject private var prefs = AppPrefsStore.shared
     @ObservedObject private var accountStore = AccountStore.shared
 
@@ -326,6 +327,8 @@ struct SettingsPage: View {
                 await MainActor.run {
                     isLoadingDemoData = false
                     appEnvironment.notifyDataDidChange()
+                    appEnvironment.showToast(message: "Demo data loaded.", iconSystemName: "checkmark.circle.fill")
+                    dismiss()
                 }
             } catch {
                 await MainActor.run {

--- a/scoremyday2Tests/AppDayRangeTests.swift
+++ b/scoremyday2Tests/AppDayRangeTests.swift
@@ -62,3 +62,30 @@ final class StatsInsightTests: XCTestCase {
         XCTAssertNil(StatsMath.pearsonCorrelation(x: netScores, y: deedPoints))
     }
 }
+
+@MainActor
+final class AppEnvironmentToastTests: XCTestCase {
+    func testToastClearsAfterDuration() async throws {
+        let environment = AppEnvironment(persistenceController: PersistenceController(inMemory: true))
+
+        environment.showToast(message: "Loaded", duration: 0.05)
+
+        XCTAssertEqual(environment.toast?.message, "Loaded")
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertNil(environment.toast)
+    }
+
+    func testLatestToastReplacesPrevious() async throws {
+        let environment = AppEnvironment(persistenceController: PersistenceController(inMemory: true))
+
+        environment.showToast(message: "First", duration: 1)
+        environment.showToast(message: "Second", duration: 1)
+
+        XCTAssertEqual(environment.toast?.message, "Second")
+
+        environment.hideToast()
+        XCTAssertNil(environment.toast)
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable toast model to the app environment and render it via a global overlay
- trigger the toast and dismiss Settings after demo data loads successfully
- cover the toast lifecycle with async unit tests

## Testing
- not run (xcodebuild not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5092557f08331ac8e0893e52a8533