### PR TITLE
Add suggestions chips and preference toggle

### DIFF
--- a/scoremyday2/Models/AppSettings.swift
+++ b/scoremyday2/Models/AppSettings.swift
@@ -5,4 +5,5 @@ struct AppSettings: Equatable {
     var hapticsEnabled: Bool = true
     var soundsEnabled: Bool = true
     var accentColorHex: String?
+    var showSuggestions: Bool = true
 }

--- a/scoremyday2/Models/DeedModels.swift
+++ b/scoremyday2/Models/DeedModels.swift
@@ -93,18 +93,21 @@ struct AppPrefs: Identifiable, Equatable {
     var hapticsOn: Bool
     var soundsOn: Bool
     var accentColorHex: String?
+    var showSuggestions: Bool
 
     init(
         id: UUID = UUID(),
         dayCutoffHour: Int = 4,
         hapticsOn: Bool = true,
         soundsOn: Bool = true,
-        accentColorHex: String? = nil
+        accentColorHex: String? = nil,
+        showSuggestions: Bool = true
     ) {
         self.id = id
         self.dayCutoffHour = dayCutoffHour
         self.hapticsOn = hapticsOn
         self.soundsOn = soundsOn
         self.accentColorHex = accentColorHex
+        self.showSuggestions = showSuggestions
     }
 }

--- a/scoremyday2/Persistence/ManagedObjects.swift
+++ b/scoremyday2/Persistence/ManagedObjects.swift
@@ -49,6 +49,7 @@ final class AppPrefsMO: NSManagedObject {
     @NSManaged var hapticsOn: Bool
     @NSManaged var soundsOn: Bool
     @NSManaged var themeAccent: String?
+    @NSManaged var showSuggestions: Bool
 }
 
 extension AppPrefsMO {

--- a/scoremyday2/Persistence/Mappings.swift
+++ b/scoremyday2/Persistence/Mappings.swift
@@ -79,7 +79,8 @@ extension AppPrefs {
             dayCutoffHour: Int(managedObject.dayCutoffHour),
             hapticsOn: managedObject.hapticsOn,
             soundsOn: managedObject.soundsOn,
-            accentColorHex: managedObject.themeAccent
+            accentColorHex: managedObject.themeAccent,
+            showSuggestions: managedObject.showSuggestions
         )
     }
 }
@@ -91,6 +92,7 @@ extension AppPrefsMO {
         hapticsOn = prefs.hapticsOn
         soundsOn = prefs.soundsOn
         themeAccent = prefs.accentColorHex
+        showSuggestions = prefs.showSuggestions
     }
 }
 

--- a/scoremyday2/Persistence/PersistenceController.swift
+++ b/scoremyday2/Persistence/PersistenceController.swift
@@ -16,6 +16,11 @@ final class PersistenceController {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
         }
 
+        if let description = container.persistentStoreDescriptions.first {
+            description.shouldMigrateStoreAutomatically = true
+            description.shouldInferMappingModelAutomatically = true
+        }
+
         container.loadPersistentStores { _, error in
             if let error = error {
                 assertionFailure("Unresolved Core Data error: \(error.localizedDescription)")
@@ -78,7 +83,8 @@ final class PersistenceController {
             attribute(name: "dayCutoffHour", type: .integer16AttributeType),
             attribute(name: "hapticsOn", type: .booleanAttributeType),
             attribute(name: "soundsOn", type: .booleanAttributeType),
-            attribute(name: "themeAccent", type: .stringAttributeType, optional: true)
+            attribute(name: "themeAccent", type: .stringAttributeType, optional: true),
+            attribute(name: "showSuggestions", type: .booleanAttributeType, defaultValue: true)
         ]
 
         let cardToEntries = NSRelationshipDescription()
@@ -137,6 +143,7 @@ final class PersistenceController {
             prefs.hapticsOn = true
             prefs.soundsOn = true
             prefs.themeAccent = nil
+            prefs.showSuggestions = true
             try context.save()
         }
     }

--- a/scoremyday2/Services/AppEnvironment.swift
+++ b/scoremyday2/Services/AppEnvironment.swift
@@ -18,6 +18,7 @@ final class AppEnvironment: ObservableObject {
         updated.hapticsEnabled = prefs.hapticsOn
         updated.soundsEnabled = prefs.soundsOn
         updated.accentColorHex = prefs.accentColorHex
+        updated.showSuggestions = prefs.showSuggestions
         settings = updated
 
         prefs.$hapticsOn
@@ -60,6 +61,17 @@ final class AppEnvironment: ObservableObject {
                 guard self.settings.accentColorHex != value else { return }
                 var current = self.settings
                 current.accentColorHex = value
+                self.settings = current
+            }
+            .store(in: &cancellables)
+
+        prefs.$showSuggestions
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                guard self.settings.showSuggestions != value else { return }
+                var current = self.settings
+                current.showSuggestions = value
                 self.settings = current
             }
             .store(in: &cancellables)

--- a/scoremyday2/Services/AppPrefsStore.swift
+++ b/scoremyday2/Services/AppPrefsStore.swift
@@ -9,6 +9,7 @@ final class AppPrefsStore: ObservableObject {
     @Published var hapticsOn: Bool
     @Published var soundsOn: Bool
     @Published var accentColorHex: String?
+    @Published var showSuggestions: Bool
 
     private let repository: AppPrefsRepository
     private var prefsID: UUID
@@ -25,6 +26,7 @@ final class AppPrefsStore: ObservableObject {
         hapticsOn = storedPrefs.hapticsOn
         soundsOn = storedPrefs.soundsOn
         accentColorHex = storedPrefs.accentColorHex
+        showSuggestions = storedPrefs.showSuggestions
 
         bindPersistence()
     }
@@ -53,6 +55,12 @@ final class AppPrefsStore: ObservableObject {
             .removeDuplicates(by: { $0 == $1 })
             .sink { [weak self] _ in self?.persistChanges() }
             .store(in: &cancellables)
+
+        $showSuggestions
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.persistChanges() }
+            .store(in: &cancellables)
     }
 
     private func persistChanges() {
@@ -63,7 +71,8 @@ final class AppPrefsStore: ObservableObject {
             dayCutoffHour: dayCutoffHour,
             hapticsOn: hapticsOn,
             soundsOn: soundsOn,
-            accentColorHex: accentColorHex
+            accentColorHex: accentColorHex,
+            showSuggestions: showSuggestions
         )
         do {
             try repository.update(prefs)

--- a/scoremyday2/Services/DeedSuggestionService.swift
+++ b/scoremyday2/Services/DeedSuggestionService.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+struct DeedSuggestionService {
+    struct CardInput {
+        let card: DeedCard
+        let lastUsed: Date?
+    }
+
+    enum Kind: String {
+        case hydration
+        case meditation
+        case positivity
+
+        var displayTitle: String {
+            switch self {
+            case .hydration:
+                return "Hydrate"
+            case .meditation:
+                return "Take a moment"
+            case .positivity:
+                return "Boost your mood"
+            }
+        }
+    }
+
+    struct Suggestion {
+        let kind: Kind
+        let cardID: UUID
+        let targetAmount: Double?
+        let note: String?
+    }
+
+    func suggestions(
+        for cards: [CardInput],
+        entries: [DeedEntry],
+        cutoffHour: Int,
+        referenceDate: Date = Date()
+    ) -> [Suggestion] {
+        guard !cards.isEmpty else { return [] }
+
+        let dayRange = appDayRange(for: referenceDate, cutoffHour: cutoffHour)
+        let todaysEntries = entries
+            .filter { entry in
+                entry.timestamp >= dayRange.start && entry.timestamp < dayRange.end
+            }
+            .sorted { $0.timestamp < $1.timestamp }
+        let entriesByCard = Dictionary(grouping: todaysEntries, by: { $0.deedId })
+
+        var results: [Suggestion] = []
+        var excluded: Set<UUID> = []
+
+        if let hydration = hydrationSuggestion(cards: cards, entriesByCard: entriesByCard, referenceDate: referenceDate, excluding: excluded) {
+            results.append(hydration)
+            excluded.insert(hydration.cardID)
+        }
+
+        if results.count < 2,
+           let meditation = meditationSuggestion(cards: cards, entriesByCard: entriesByCard, excluding: excluded) {
+            results.append(meditation)
+            excluded.insert(meditation.cardID)
+        }
+
+        if results.count < 2,
+           let positivity = positivitySuggestion(cards: cards, todaysEntries: todaysEntries, excluding: excluded, referenceDate: referenceDate) {
+            results.append(positivity)
+        }
+
+        return Array(results.prefix(2))
+    }
+
+    private func hydrationSuggestion(
+        cards: [CardInput],
+        entriesByCard: [UUID: [DeedEntry]],
+        referenceDate: Date,
+        excluding excluded: Set<UUID>
+    ) -> Suggestion? {
+        let keywords = ["water", "hydrate", "hydration", "drink"]
+        let hydrationCards = cards.filter { input in
+            guard !excluded.contains(input.card.id) else { return false }
+            guard input.card.polarity == .positive, input.card.unitType == .quantity else { return false }
+            let name = input.card.name.lowercased()
+            let label = input.card.unitLabel.lowercased()
+            let category = input.card.category.lowercased()
+            if keywords.contains(where: { name.contains($0) || label.contains($0) || category.contains($0) }) {
+                return true
+            }
+            return input.card.emoji.contains("💧")
+        }
+
+        guard let candidate = hydrationCards.first else { return nil }
+        let todaysAmount = entriesByCard[candidate.card.id]?.reduce(0) { $0 + max(0, $1.amount) } ?? 0
+        let lastEntry = entriesByCard[candidate.card.id]?.max(by: { $0.timestamp < $1.timestamp })?.timestamp
+        let hydrationGoal: Double = 2000
+        let minimumSpacing: TimeInterval = 60 * 75 // 1h 15m
+        let needsMoreToday = todaysAmount < hydrationGoal
+        let spacedOut = lastEntry.map { referenceDate.timeIntervalSince($0) >= minimumSpacing } ?? true
+        guard needsMoreToday && spacedOut else { return nil }
+
+        return Suggestion(kind: .hydration, cardID: candidate.card.id, targetAmount: nil, note: nil)
+    }
+
+    private func meditationSuggestion(
+        cards: [CardInput],
+        entriesByCard: [UUID: [DeedEntry]],
+        excluding excluded: Set<UUID>
+    ) -> Suggestion? {
+        let keywords = ["meditat", "mindful", "breathe", "breath", "calm"]
+        for input in cards where !excluded.contains(input.card.id) {
+            guard input.card.polarity == .positive, input.card.unitType == .duration else { continue }
+            let name = input.card.name.lowercased()
+            let category = input.card.category.lowercased()
+            guard keywords.contains(where: { name.contains($0) || category.contains($0) }) else { continue }
+            let hasEntryToday = entriesByCard[input.card.id]?.isEmpty == false
+            if !hasEntryToday {
+                return Suggestion(kind: .meditation, cardID: input.card.id, targetAmount: nil, note: nil)
+            }
+        }
+        return nil
+    }
+
+    private func positivitySuggestion(
+        cards: [CardInput],
+        todaysEntries: [DeedEntry],
+        excluding excluded: Set<UUID>,
+        referenceDate: Date
+    ) -> Suggestion? {
+        let negativeEntries = todaysEntries.filter { $0.computedPoints < 0 }
+        guard let latestNegative = negativeEntries.max(by: { $0.timestamp < $1.timestamp }) else { return nil }
+        let recentWindow: TimeInterval = 60 * 120 // 2 hours
+        guard referenceDate.timeIntervalSince(latestNegative.timestamp) <= recentWindow else { return nil }
+        let positiveAfterNegative = todaysEntries.first { entry in
+            entry.computedPoints > 0 && entry.timestamp > latestNegative.timestamp
+        }
+        guard positiveAfterNegative == nil else { return nil }
+
+        for input in cards where !excluded.contains(input.card.id) {
+            guard input.card.polarity == .positive else { continue }
+            return Suggestion(kind: .positivity, cardID: input.card.id, targetAmount: nil, note: nil)
+        }
+        return nil
+    }
+}

--- a/scoremyday2/UI/Pages/SettingsPage.swift
+++ b/scoremyday2/UI/Pages/SettingsPage.swift
@@ -135,6 +135,7 @@ struct SettingsPage: View {
 
             Toggle("Haptics", isOn: $prefs.hapticsOn)
             Toggle("Sounds", isOn: $prefs.soundsOn)
+            Toggle("Suggestions", isOn: $prefs.showSuggestions)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Accent Color")


### PR DESCRIPTION
## Summary
- add a horizontally scrolling suggestions area on the Deeds page that logs prefilled entries and reacts instantly
- back the chips with a new suggestion service and view-model state for hydration, meditation, and positivity heuristics
- persist a showSuggestions preference with settings toggle, environment propagation, and Core Data schema updates

## Testing
- not run (Xcode build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e508f8654083318d02112aec7ff142