### PR TITLE
Add deed suggestions chips and preference toggle

### DIFF
--- a/scoremyday2/Models/AppSettings.swift
+++ b/scoremyday2/Models/AppSettings.swift
@@ -5,4 +5,5 @@ struct AppSettings: Equatable {
     var hapticsEnabled: Bool = true
     var soundsEnabled: Bool = true
     var accentColorHex: String?
+    var showSuggestions: Bool = true
 }

--- a/scoremyday2/Models/DeedModels.swift
+++ b/scoremyday2/Models/DeedModels.swift
@@ -93,18 +93,21 @@ struct AppPrefs: Identifiable, Equatable {
     var hapticsOn: Bool
     var soundsOn: Bool
     var accentColorHex: String?
+    var showSuggestions: Bool
 
     init(
         id: UUID = UUID(),
         dayCutoffHour: Int = 4,
         hapticsOn: Bool = true,
         soundsOn: Bool = true,
-        accentColorHex: String? = nil
+        accentColorHex: String? = nil,
+        showSuggestions: Bool = true
     ) {
         self.id = id
         self.dayCutoffHour = dayCutoffHour
         self.hapticsOn = hapticsOn
         self.soundsOn = soundsOn
         self.accentColorHex = accentColorHex
+        self.showSuggestions = showSuggestions
     }
 }

--- a/scoremyday2/Persistence/ManagedObjects.swift
+++ b/scoremyday2/Persistence/ManagedObjects.swift
@@ -49,6 +49,7 @@ final class AppPrefsMO: NSManagedObject {
     @NSManaged var hapticsOn: Bool
     @NSManaged var soundsOn: Bool
     @NSManaged var themeAccent: String?
+    @NSManaged var showSuggestions: Bool
 }
 
 extension AppPrefsMO {

--- a/scoremyday2/Persistence/Mappings.swift
+++ b/scoremyday2/Persistence/Mappings.swift
@@ -79,7 +79,8 @@ extension AppPrefs {
             dayCutoffHour: Int(managedObject.dayCutoffHour),
             hapticsOn: managedObject.hapticsOn,
             soundsOn: managedObject.soundsOn,
-            accentColorHex: managedObject.themeAccent
+            accentColorHex: managedObject.themeAccent,
+            showSuggestions: managedObject.showSuggestions
         )
     }
 }
@@ -91,6 +92,7 @@ extension AppPrefsMO {
         hapticsOn = prefs.hapticsOn
         soundsOn = prefs.soundsOn
         themeAccent = prefs.accentColorHex
+        showSuggestions = prefs.showSuggestions
     }
 }
 

--- a/scoremyday2/Persistence/PersistenceController.swift
+++ b/scoremyday2/Persistence/PersistenceController.swift
@@ -78,7 +78,8 @@ final class PersistenceController {
             attribute(name: "dayCutoffHour", type: .integer16AttributeType),
             attribute(name: "hapticsOn", type: .booleanAttributeType),
             attribute(name: "soundsOn", type: .booleanAttributeType),
-            attribute(name: "themeAccent", type: .stringAttributeType, optional: true)
+            attribute(name: "themeAccent", type: .stringAttributeType, optional: true),
+            attribute(name: "showSuggestions", type: .booleanAttributeType, defaultValue: true)
         ]
 
         let cardToEntries = NSRelationshipDescription()
@@ -137,6 +138,7 @@ final class PersistenceController {
             prefs.hapticsOn = true
             prefs.soundsOn = true
             prefs.themeAccent = nil
+            prefs.showSuggestions = true
             try context.save()
         }
     }

--- a/scoremyday2/Services/AppEnvironment.swift
+++ b/scoremyday2/Services/AppEnvironment.swift
@@ -18,6 +18,7 @@ final class AppEnvironment: ObservableObject {
         updated.hapticsEnabled = prefs.hapticsOn
         updated.soundsEnabled = prefs.soundsOn
         updated.accentColorHex = prefs.accentColorHex
+        updated.showSuggestions = prefs.showSuggestions
         settings = updated
 
         prefs.$hapticsOn
@@ -60,6 +61,17 @@ final class AppEnvironment: ObservableObject {
                 guard self.settings.accentColorHex != value else { return }
                 var current = self.settings
                 current.accentColorHex = value
+                self.settings = current
+            }
+            .store(in: &cancellables)
+
+        prefs.$showSuggestions
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                guard self.settings.showSuggestions != value else { return }
+                var current = self.settings
+                current.showSuggestions = value
                 self.settings = current
             }
             .store(in: &cancellables)

--- a/scoremyday2/Services/AppPrefsStore.swift
+++ b/scoremyday2/Services/AppPrefsStore.swift
@@ -9,6 +9,7 @@ final class AppPrefsStore: ObservableObject {
     @Published var hapticsOn: Bool
     @Published var soundsOn: Bool
     @Published var accentColorHex: String?
+    @Published var showSuggestions: Bool
 
     private let repository: AppPrefsRepository
     private var prefsID: UUID
@@ -25,6 +26,7 @@ final class AppPrefsStore: ObservableObject {
         hapticsOn = storedPrefs.hapticsOn
         soundsOn = storedPrefs.soundsOn
         accentColorHex = storedPrefs.accentColorHex
+        showSuggestions = storedPrefs.showSuggestions
 
         bindPersistence()
     }
@@ -53,6 +55,12 @@ final class AppPrefsStore: ObservableObject {
             .removeDuplicates(by: { $0 == $1 })
             .sink { [weak self] _ in self?.persistChanges() }
             .store(in: &cancellables)
+
+        $showSuggestions
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.persistChanges() }
+            .store(in: &cancellables)
     }
 
     private func persistChanges() {
@@ -63,7 +71,8 @@ final class AppPrefsStore: ObservableObject {
             dayCutoffHour: dayCutoffHour,
             hapticsOn: hapticsOn,
             soundsOn: soundsOn,
-            accentColorHex: accentColorHex
+            accentColorHex: accentColorHex,
+            showSuggestions: showSuggestions
         )
         do {
             try repository.update(prefs)

--- a/scoremyday2/Services/DeedSuggestionsService.swift
+++ b/scoremyday2/Services/DeedSuggestionsService.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+struct DeedSuggestion: Identifiable, Equatable {
+    enum Kind: String {
+        case hydration
+        case meditation
+        case positiveLog
+    }
+
+    let kind: Kind
+    let cardID: UUID
+
+    var id: String { "\(kind.rawValue)-\(cardID.uuidString)" }
+}
+
+struct DeedSuggestionsService {
+    private let hydrationKeywords = ["water", "hydrate", "hydration", "h2o"]
+    private let hydrationEmojis: Set<String> = ["💧", "🚰", "🫗", "🥤", "🧊"]
+    private let meditationKeywords = ["meditate", "meditation", "mindful", "breath", "breathing"]
+    private let meditationEmojis: Set<String> = ["🧘", "🧘‍♀️", "🧘‍♂️"]
+    private let positiveKeywords = ["positive", "gratitude", "journal", "log", "highlight", "win", "wins"]
+
+    func makeSuggestions(
+        cards: [DeedCard],
+        entries: [DeedEntry],
+        cutoffHour: Int,
+        referenceDate: Date = Date()
+    ) -> [DeedSuggestion] {
+        guard !cards.isEmpty else { return [] }
+
+        let dayRange = appDayRange(for: referenceDate, cutoffHour: cutoffHour)
+        let todaysEntries = entries.filter { entry in
+            entry.timestamp >= dayRange.start && entry.timestamp < dayRange.end
+        }
+        let entriesByCard = Dictionary(grouping: todaysEntries, by: { $0.deedId })
+
+        var suggestions: [DeedSuggestion] = []
+        var usedCardIDs: Set<UUID> = []
+
+        if let hydration = hydrationSuggestion(from: cards, entriesByCard: entriesByCard, usedCardIDs: &usedCardIDs) {
+            suggestions.append(hydration)
+        }
+
+        if suggestions.count < 2,
+           let meditation = meditationSuggestion(from: cards, entriesByCard: entriesByCard, usedCardIDs: &usedCardIDs) {
+            suggestions.append(meditation)
+        }
+
+        if suggestions.count < 2,
+           let positive = positiveLogSuggestion(
+                from: cards,
+                entriesByCard: entriesByCard,
+                todaysEntries: todaysEntries,
+                usedCardIDs: &usedCardIDs
+           ) {
+            suggestions.append(positive)
+        }
+
+        return Array(suggestions.prefix(2))
+    }
+
+    private func hydrationSuggestion(
+        from cards: [DeedCard],
+        entriesByCard: [UUID: [DeedEntry]],
+        usedCardIDs: inout Set<UUID>
+    ) -> DeedSuggestion? {
+        guard let card = cards.first(where: { candidate in
+            guard candidate.polarity == .positive else { return false }
+            guard entriesByCard[candidate.id] == nil else { return false }
+            let name = candidate.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                .lowercased()
+            if hydrationKeywords.contains(where: { name.contains($0) }) { return true }
+            return hydrationEmojis.contains(candidate.emoji)
+        }) else {
+            return nil
+        }
+
+        usedCardIDs.insert(card.id)
+        return DeedSuggestion(kind: .hydration, cardID: card.id)
+    }
+
+    private func meditationSuggestion(
+        from cards: [DeedCard],
+        entriesByCard: [UUID: [DeedEntry]],
+        usedCardIDs: inout Set<UUID>
+    ) -> DeedSuggestion? {
+        guard let card = cards.first(where: { candidate in
+            guard candidate.polarity == .positive else { return false }
+            guard !usedCardIDs.contains(candidate.id) else { return false }
+            guard entriesByCard[candidate.id] == nil else { return false }
+            let name = candidate.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+                .lowercased()
+            if meditationKeywords.contains(where: { name.contains($0) }) { return true }
+            return meditationEmojis.contains(candidate.emoji)
+        }) else {
+            return nil
+        }
+
+        usedCardIDs.insert(card.id)
+        return DeedSuggestion(kind: .meditation, cardID: card.id)
+    }
+
+    private func positiveLogSuggestion(
+        from cards: [DeedCard],
+        entriesByCard: [UUID: [DeedEntry]],
+        todaysEntries: [DeedEntry],
+        usedCardIDs: inout Set<UUID>
+    ) -> DeedSuggestion? {
+        let hasPositiveEntry = todaysEntries.contains(where: { $0.computedPoints > 0 })
+        guard !hasPositiveEntry else { return nil }
+
+        let enumerated = cards.enumerated().filter { element in
+            let card = element.element
+            guard card.polarity == .positive else { return false }
+            guard !usedCardIDs.contains(card.id) else { return false }
+            guard entriesByCard[card.id] == nil else { return false }
+            return card.unitType != .rating
+        }
+
+        guard !enumerated.isEmpty else { return nil }
+
+        let prioritized = enumerated.sorted { lhs, rhs in
+            let lhsPriority = positivePriority(for: lhs.element)
+            let rhsPriority = positivePriority(for: rhs.element)
+            if lhsPriority != rhsPriority {
+                return lhsPriority < rhsPriority
+            }
+
+            let lhsMatches = matchesPositiveKeyword(lhs.element)
+            let rhsMatches = matchesPositiveKeyword(rhs.element)
+            if lhsMatches != rhsMatches {
+                return lhsMatches
+            }
+
+            return lhs.offset < rhs.offset
+        }
+
+        guard let card = prioritized.first?.element else { return nil }
+        usedCardIDs.insert(card.id)
+        return DeedSuggestion(kind: .positiveLog, cardID: card.id)
+    }
+
+    private func positivePriority(for card: DeedCard) -> Int {
+        switch card.unitType {
+        case .boolean:
+            return 0
+        case .count:
+            return 1
+        case .duration:
+            return 2
+        case .quantity:
+            return 3
+        case .rating:
+            return 4
+        }
+    }
+
+    private func matchesPositiveKeyword(_ card: DeedCard) -> Bool {
+        let name = card.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current).lowercased()
+        return positiveKeywords.contains(where: { name.contains($0) })
+    }
+}

--- a/scoremyday2/UI/Pages/DeedsPage.swift
+++ b/scoremyday2/UI/Pages/DeedsPage.swift
@@ -33,6 +33,10 @@ struct DeedsPage: View {
 
                     ScrollView {
                         VStack(alignment: .leading, spacing: 28) {
+                            if appEnvironment.settings.showSuggestions, !viewModel.suggestions.isEmpty {
+                                suggestionsSection
+                            }
+
                             headerView
                                 .padding(.top, 32)
                                 .anchorPreference(key: HeaderFramePreferenceKey.self, value: .bounds) { $0 }
@@ -126,6 +130,42 @@ struct DeedsPage: View {
         ))
     }
 
+    private var suggestionsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Suggestions")
+                .font(.caption.weight(.semibold))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                ForEach(viewModel.suggestions) { suggestion in
+                    Button {
+                        handleSuggestionTap(suggestion)
+                    } label: {
+                        HStack(spacing: 8) {
+                            Text(suggestion.card.card.emoji)
+                                .font(.system(size: 16))
+                            Text(suggestion.card.card.name)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.primary)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(
+                            Capsule()
+                                .fill(suggestion.card.accentColor.opacity(0.22))
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Log \(suggestion.card.card.name)")
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 18)
+        .glassBackground(cornerRadius: 28, tint: Color.accentColor, warpStrength: 3)
+    }
+
     private var headerView: some View {
         HStack(alignment: .center, spacing: 16) {
             VStack(alignment: .leading, spacing: 6) {
@@ -188,6 +228,20 @@ struct DeedsPage: View {
             let entry = result.entry
             handleFeedback(for: card.card.polarity, points: entry.computedPoints, cardID: card.id, startFrameOverride: startFrame)
             handleDailyCapHint(for: card, result: result)
+        }
+    }
+
+    private func handleSuggestionTap(_ suggestion: DeedsPageViewModel.SuggestionState) {
+        let startFrame = cardFrames[suggestion.card.id]
+        if let result = viewModel.performSuggestion(suggestion) {
+            let entry = result.entry
+            handleFeedback(
+                for: suggestion.card.card.polarity,
+                points: entry.computedPoints,
+                cardID: suggestion.card.id,
+                startFrameOverride: startFrame
+            )
+            handleDailyCapHint(for: suggestion.card, result: result)
         }
     }
 

--- a/scoremyday2/UI/Pages/SettingsPage.swift
+++ b/scoremyday2/UI/Pages/SettingsPage.swift
@@ -135,6 +135,7 @@ struct SettingsPage: View {
 
             Toggle("Haptics", isOn: $prefs.hapticsOn)
             Toggle("Sounds", isOn: $prefs.soundsOn)
+            Toggle("Suggestions", isOn: $prefs.showSuggestions)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text("Accent Color")


### PR DESCRIPTION
## Summary
- add a DeedSuggestionsService and view-model state to surface up to two suggestion chips for hydration, meditation, or positive logging
- store a user-controlled showSuggestions preference across AppPrefs, expose toggle in Settings, and publish through AppEnvironment
- render the suggestions at the top of DeedsPage and log entries immediately when chips are tapped

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68e50c3391f48331b992eadf13f63d5a