### PR TITLE
Fix missing closing brace in DeedsPage

### DIFF
--- a/scoremyday2/UI/Pages/DeedsPage.swift
+++ b/scoremyday2/UI/Pages/DeedsPage.swift
@@ -730,6 +730,7 @@ private struct RatingPickerSheet: View {
         .onAppear {
             rating = Int(card.lastAmount ?? 3)
         }
+    }
 }
 
 #Preview {


### PR DESCRIPTION
## Summary
- add the missing closing brace to `RatingPickerSheet` so the struct compiles again

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e50ed47af083318abb9b48d664691f