### PR TITLE
Fix refreshSuggestions placement in DeedsPageViewModel

### DIFF
--- a/scoremyday2/UI/Pages/DeedsPageViewModel.swift
+++ b/scoremyday2/UI/Pages/DeedsPageViewModel.swift
@@ -292,7 +292,6 @@ final class DeedsPageViewModel: ObservableObject {
 
         return lhsID.uuidString < rhsID.uuidString
     }
-}
 
     private func refreshSuggestions(using baseCards: [DeedCard]? = nil) {
         let cardsToUse: [DeedCard]
@@ -325,6 +324,8 @@ final class DeedsPageViewModel: ObservableObject {
             suggestions = mapped
         }
     }
+
+}
 
 private struct LastAmountStore {
     private let defaults: UserDefaults


### PR DESCRIPTION
## Summary
- keep `refreshSuggestions` inside `DeedsPageViewModel` so the class continues to conform to `ObservableObject`

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e50fd4b3fc8331b9c04e8d38478e31