### PR TITLE
Fix Combine imports and export models

### DIFF
--- a/scoremyday2/Services/AccountStore.swift
+++ b/scoremyday2/Services/AccountStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 @MainActor
 final class AccountStore: ObservableObject {

--- a/scoremyday2/Services/DataExportService.swift
+++ b/scoremyday2/Services/DataExportService.swift
@@ -67,7 +67,7 @@ struct DataExportService {
 }
 
 private extension DataExportService {
-    struct ExportableCard: Codable {
+    struct ExportableCard: Encodable {
         let id: UUID
         let name: String
         let emoji: String
@@ -157,7 +157,7 @@ private extension DataExportService {
         ]
     }
 
-    struct ExportableEntry: Codable {
+    struct ExportableEntry: Encodable {
         let id: UUID
         let deedId: UUID
         let timestamp: Date


### PR DESCRIPTION
## Summary
- add the Combine import to `AccountStore` so it builds with `@Published`
- constrain the data export helper types to `Encodable` to avoid decoding synthesis issues

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e51237df448331bcfe18c75601462b