### PR TITLE
Fix SwiftUI compilation issues

### DIFF
--- a/scoremyday2/UI/Components/ParticleOverlayView.swift
+++ b/scoremyday2/UI/Components/ParticleOverlayView.swift
@@ -36,7 +36,7 @@ extension ParticleOverlayView {
     }
 }
 
-private final class ParticleOverlayUIView: UIView {
+final class ParticleOverlayUIView: UIView {
     private var activeEmitters: [UUID: CAEmitterLayer] = [:]
     private lazy var particleImage: CGImage? = Self.makeParticleImage()
 

--- a/scoremyday2/UI/Pages/StatsPage.swift
+++ b/scoremyday2/UI/Pages/StatsPage.swift
@@ -1,4 +1,5 @@
 import Charts
+import Combine
 import CoreData
 import SwiftUI
 


### PR DESCRIPTION
## Summary
- import Combine in StatsPage to allow ObservableObject and property wrappers to compile
- relax access control on ParticleOverlayUIView so UIViewRepresentable methods can reference it

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e512ec11ec8331a0c71546692833b8