### PR TITLE
Adjust deeds grid to three columns

### DIFF
--- a/scoremyday2/UI/Pages/DeedsPage.swift
+++ b/scoremyday2/UI/Pages/DeedsPage.swift
@@ -196,7 +196,7 @@ struct DeedsPage: View {
     }
 
     private var cardsGrid: some View {
-        let columns = Array(repeating: GridItem(.flexible(), spacing: 14, alignment: .top), count: 5)
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 14, alignment: .top), count: 3)
         return LazyVGrid(columns: columns, spacing: 14) {
             ForEach(viewModel.cards) { card in
                 DeedCardTile(


### PR DESCRIPTION
## Summary
- update the Deeds page grid to use three columns so cards present in a 3x4 layout

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e52b8fc3d88331bdeaeb8b8bf409af