### PR TITLE
Fix actor isolation warnings and modernize onChange usage

### DIFF
--- a/scoremyday2/Repositories/DeedsRepository.swift
+++ b/scoremyday2/Repositories/DeedsRepository.swift
@@ -1,6 +1,7 @@
 import CoreData
 import Foundation
 
+@MainActor
 final class DeedsRepository {
     private let context: NSManagedObjectContext
 

--- a/scoremyday2/Repositories/EntriesRepository.swift
+++ b/scoremyday2/Repositories/EntriesRepository.swift
@@ -13,6 +13,7 @@ struct LogEntryResult {
     let wasCapped: Bool
 }
 
+@MainActor
 final class EntriesRepository {
     private let context: NSManagedObjectContext
 

--- a/scoremyday2/Services/AppEnvironment.swift
+++ b/scoremyday2/Services/AppEnvironment.swift
@@ -7,20 +7,21 @@ final class AppEnvironment: ObservableObject {
     @Published var selectedTab: RootTab = .deeds
     @Published var dataVersion: Int = 0
     let persistenceController: PersistenceController
+    private let prefsStore: AppPrefsStore
     private var cancellables: Set<AnyCancellable> = []
 
-    init(persistenceController: PersistenceController = .shared) {
+    init(persistenceController: PersistenceController, prefsStore: AppPrefsStore) {
         self.persistenceController = persistenceController
+        self.prefsStore = prefsStore
 
-        let prefs = AppPrefsStore.shared
         var updated = settings
-        updated.dayCutoffHour = prefs.dayCutoffHour
-        updated.hapticsEnabled = prefs.hapticsOn
-        updated.soundsEnabled = prefs.soundsOn
-        updated.accentColorHex = prefs.accentColorHex
+        updated.dayCutoffHour = prefsStore.dayCutoffHour
+        updated.hapticsEnabled = prefsStore.hapticsOn
+        updated.soundsEnabled = prefsStore.soundsOn
+        updated.accentColorHex = prefsStore.accentColorHex
         settings = updated
 
-        prefs.$hapticsOn
+        prefsStore.$hapticsOn
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
@@ -31,7 +32,7 @@ final class AppEnvironment: ObservableObject {
             }
             .store(in: &cancellables)
 
-        prefs.$soundsOn
+        prefsStore.$soundsOn
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
@@ -42,7 +43,7 @@ final class AppEnvironment: ObservableObject {
             }
             .store(in: &cancellables)
 
-        prefs.$dayCutoffHour
+        prefsStore.$dayCutoffHour
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
@@ -53,7 +54,7 @@ final class AppEnvironment: ObservableObject {
             }
             .store(in: &cancellables)
 
-        prefs.$accentColorHex
+        prefsStore.$accentColorHex
             .removeDuplicates(by: { $0 == $1 })
             .sink { [weak self] value in
                 guard let self else { return }
@@ -64,6 +65,10 @@ final class AppEnvironment: ObservableObject {
             }
             .store(in: &cancellables)
 
+    }
+
+    convenience init(persistenceController: PersistenceController = .shared) {
+        self.init(persistenceController: persistenceController, prefsStore: .shared)
     }
 
     func notifyDataDidChange() {

--- a/scoremyday2/Services/AppPrefsStore.swift
+++ b/scoremyday2/Services/AppPrefsStore.swift
@@ -15,7 +15,7 @@ final class AppPrefsStore: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private var isPersisting = false
 
-    init(persistenceController: PersistenceController = .shared) {
+    init(persistenceController: PersistenceController) {
         let context = persistenceController.viewContext
         repository = AppPrefsRepository(context: context)
 
@@ -27,6 +27,10 @@ final class AppPrefsStore: ObservableObject {
         accentColorHex = storedPrefs.accentColorHex
 
         bindPersistence()
+    }
+
+    convenience init() {
+        self.init(persistenceController: .shared)
     }
 
     private func bindPersistence() {

--- a/scoremyday2/Services/DataExportService.swift
+++ b/scoremyday2/Services/DataExportService.swift
@@ -1,6 +1,7 @@
 import CoreData
 import Foundation
 
+@MainActor
 struct DataExportService {
     private let deedsRepository: DeedsRepository
     private let entriesRepository: EntriesRepository

--- a/scoremyday2/UI/Pages/AddEditDeedSheet.swift
+++ b/scoremyday2/UI/Pages/AddEditDeedSheet.swift
@@ -169,10 +169,10 @@ struct AddEditDeedSheet: View {
                 }
             }
         }
-        .onChange(of: unitType) { newValue in
+        .onChange(of: unitType) { _, newValue in
             applyDefaults(for: newValue)
         }
-        .onChange(of: polarity) { newValue in
+        .onChange(of: polarity) { _, newValue in
             syncPointsWithPolarity()
             enforceBooleanDailyCapIfNeeded(force: unitType == .boolean && newValue == .negative)
         }

--- a/scoremyday2/UI/Pages/DeedsPage.swift
+++ b/scoremyday2/UI/Pages/DeedsPage.swift
@@ -77,10 +77,10 @@ struct DeedsPage: View {
         }
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: capHint?.id)
         .onAppear { viewModel.onAppear() }
-        .onChange(of: appEnvironment.settings.dayCutoffHour) { newValue in
+        .onChange(of: appEnvironment.settings.dayCutoffHour) { _, newValue in
             viewModel.updateCutoffHour(newValue)
         }
-        .onChange(of: appEnvironment.dataVersion) { _ in
+        .onChange(of: appEnvironment.dataVersion) {
             viewModel.reload()
         }
         .sheet(item: $quickAddState) { state in

--- a/scoremyday2/UI/Pages/SettingsPage.swift
+++ b/scoremyday2/UI/Pages/SettingsPage.swift
@@ -33,7 +33,7 @@ struct SettingsPage: View {
             .onAppear {
                 SoundManager.shared.preload()
             }
-            .onChange(of: prefs.dayCutoffHour) { newValue in
+            .onChange(of: prefs.dayCutoffHour) { _, newValue in
                 let newDate = SettingsPage.makeDate(forHour: newValue)
                 if Calendar.current.component(.hour, from: dayCutoffSelection) != newValue {
                     dayCutoffSelection = newDate
@@ -128,7 +128,7 @@ struct SettingsPage: View {
             )
             .datePickerStyle(.wheel)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .onChange(of: dayCutoffSelection) { newValue in
+            .onChange(of: dayCutoffSelection) { _, newValue in
                 updateDayCutoff(with: newValue)
             }
 

--- a/scoremyday2/Utilities/MotionTransparency.swift
+++ b/scoremyday2/Utilities/MotionTransparency.swift
@@ -9,8 +9,8 @@ struct MotionTransparencyEnv: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onChange(of: reduceMotion) { disableParticles($0) }
-            .onChange(of: reduceTransparency) { setOpaqueBackgrounds($0) }
+            .onChange(of: reduceMotion) { _, value in disableParticles(value) }
+            .onChange(of: reduceTransparency) { _, value in setOpaqueBackgrounds(value) }
             .onAppear {
                 disableParticles(reduceMotion)
                 setOpaqueBackgrounds(reduceTransparency)


### PR DESCRIPTION
## Summary
- mark Core Data repositories and the export service as main actor isolated to satisfy new concurrency checks
- refactor AppEnvironment and AppPrefsStore initialisers to inject shared dependencies safely
- update SwiftUI onChange handlers to the iOS 17 two-parameter/closure form

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5b36e25d8833189b7649259d5112c