### PR TITLE
Fix main-actor access for shared services

### DIFF
--- a/scoremyday2/Services/AppEnvironment.swift
+++ b/scoremyday2/Services/AppEnvironment.swift
@@ -67,8 +67,14 @@ final class AppEnvironment: ObservableObject {
 
     }
 
-    convenience init(persistenceController: PersistenceController = .shared) {
-        self.init(persistenceController: persistenceController, prefsStore: .shared)
+    convenience init(
+        persistenceController: PersistenceController? = nil,
+        prefsStore: AppPrefsStore? = nil
+    ) {
+        self.init(
+            persistenceController: persistenceController ?? .shared,
+            prefsStore: prefsStore ?? AppPrefsStore.shared
+        )
     }
 
     func notifyDataDidChange() {

--- a/scoremyday2/Services/DataMaintenanceService.swift
+++ b/scoremyday2/Services/DataMaintenanceService.swift
@@ -8,7 +8,8 @@ struct DataMaintenanceService {
         self.context = context
     }
 
-    init(persistenceController: PersistenceController = .shared) {
+    init(persistenceController: PersistenceController? = nil) {
+        let persistenceController = persistenceController ?? .shared
         self.init(context: persistenceController.viewContext)
     }
 

--- a/scoremyday2/UI/Pages/DeedsPageViewModel.swift
+++ b/scoremyday2/UI/Pages/DeedsPageViewModel.swift
@@ -31,7 +31,8 @@ final class DeedsPageViewModel: ObservableObject {
 
     private var hasLoaded = false
 
-    init(persistenceController: PersistenceController = .shared) {
+    init(persistenceController: PersistenceController? = nil) {
+        let persistenceController = persistenceController ?? .shared
         let context = persistenceController.viewContext
         self.deedsRepository = DeedsRepository(context: context)
         self.entriesRepository = EntriesRepository(context: context)


### PR DESCRIPTION
## Summary
- avoid referencing main-actor isolated singletons in default parameter values by allowing optional dependencies in environment and service initializers
- construct CSV number formatters locally and inject them into export models so they no longer rely on main-actor static properties

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5b61c090c8331a68c63b8f21f45c0