### PR TITLE
Add default deed seeds for demo cards

### DIFF
--- a/scoremyday2/Services/InitialDataSeeder.swift
+++ b/scoremyday2/Services/InitialDataSeeder.swift
@@ -80,5 +80,175 @@ struct InitialDataSeeder {
 }
 
 private extension DefaultDeedCardSeed {
-    static let all: [DefaultDeedCardSeed] = []
+    static let all: [DefaultDeedCardSeed] = [
+        DefaultDeedCardSeed(
+            name: "Morning Walk",
+            emoji: "🚶",
+            category: "Wellness",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "minutes",
+            pointsPerUnit: 4,
+            dailyCap: 45,
+            colorHex: "#34C759",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Meditation",
+            emoji: "🧘",
+            category: "Mindfulness",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "minutes",
+            pointsPerUnit: 5,
+            dailyCap: 30,
+            colorHex: "#AF52DE",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Hydrate",
+            emoji: "💧",
+            category: "Wellness",
+            polarity: .positive,
+            unitType: .count,
+            unitLabel: "glass",
+            pointsPerUnit: 3,
+            dailyCap: 8,
+            colorHex: "#32ADE6",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Healthy Meal",
+            emoji: "🥗",
+            category: "Nutrition",
+            polarity: .positive,
+            unitType: .count,
+            unitLabel: "meal",
+            pointsPerUnit: 12,
+            dailyCap: 3,
+            colorHex: "#FF9500",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Stretch Break",
+            emoji: "🧘‍♀️",
+            category: "Wellness",
+            polarity: .positive,
+            unitType: .duration,
+            unitLabel: "minutes",
+            pointsPerUnit: 2,
+            dailyCap: 20,
+            colorHex: "#FF2D55",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Read a Chapter",
+            emoji: "📚",
+            category: "Growth",
+            polarity: .positive,
+            unitType: .count,
+            unitLabel: "chapter",
+            pointsPerUnit: 10,
+            dailyCap: 2,
+            colorHex: "#FFD60A",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Budget Check",
+            emoji: "💸",
+            category: "Life",
+            polarity: .positive,
+            unitType: .boolean,
+            unitLabel: "Completed",
+            pointsPerUnit: 20,
+            dailyCap: 1,
+            colorHex: "#FF9F0A",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Sleep Quality",
+            emoji: "😴",
+            category: "Wellness",
+            polarity: .positive,
+            unitType: .rating,
+            unitLabel: "rating",
+            pointsPerUnit: 6,
+            dailyCap: nil,
+            colorHex: "#0A84FF",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Evening Unplug",
+            emoji: "📵",
+            category: "Mindfulness",
+            polarity: .positive,
+            unitType: .boolean,
+            unitLabel: "Completed",
+            pointsPerUnit: 15,
+            dailyCap: 1,
+            colorHex: "#30B0C7",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Junk Food",
+            emoji: "🍟",
+            category: "Nutrition",
+            polarity: .negative,
+            unitType: .count,
+            unitLabel: "serving",
+            pointsPerUnit: -8,
+            dailyCap: nil,
+            colorHex: "#FF453A",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Late Night Scroll",
+            emoji: "📱",
+            category: "Mindfulness",
+            polarity: .negative,
+            unitType: .duration,
+            unitLabel: "minutes",
+            pointsPerUnit: -3,
+            dailyCap: nil,
+            colorHex: "#5856D6",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Impulse Buy",
+            emoji: "🛍️",
+            category: "Life",
+            polarity: .negative,
+            unitType: .boolean,
+            unitLabel: "Made purchase",
+            pointsPerUnit: -25,
+            dailyCap: nil,
+            colorHex: "#8E8E93",
+            isPrivate: false,
+            showOnStats: true
+        ),
+        DefaultDeedCardSeed(
+            name: "Skipped Workout",
+            emoji: "🙈",
+            category: "Fitness",
+            polarity: .negative,
+            unitType: .boolean,
+            unitLabel: "Skipped",
+            pointsPerUnit: -18,
+            dailyCap: nil,
+            colorHex: "#FF3B30",
+            isPrivate: false,
+            showOnStats: true
+        )
+    ]
 }


### PR DESCRIPTION
## Summary
- populate the initial data seeder with a curated list of positive and negative deed cards so new installs show interactive demo content

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5f73258d8833188d4395b141e146d