### PR TITLE
Add helper to clean corrupted build database

### DIFF
--- a/Scripts/clean_build.sh
+++ b/Scripts/clean_build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+BUILD_DIR="$ROOT_DIR/Build"
+
+if [ ! -d "$BUILD_DIR" ]; then
+  echo "No Build directory found at $BUILD_DIR"
+  exit 0
+fi
+
+find "$BUILD_DIR" -name "build.db" -delete
+echo "Removed cached build databases under $BUILD_DIR"
+
+# Remove any stale XCBuildData folders that can corrupt incremental builds
+find "$BUILD_DIR" -name "XCBuildData" -type d -prune -exec rm -rf {} +
+echo "Removed XCBuildData directories"

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+## "no more rows available" build error
+
+If Xcode or `xcodebuild` fails with an error similar to:
+
+```
+error: accessing build database ".../Build/Intermediates.noindex/XCBuildData/build.db": no more rows available
+The build service has encountered an internal inconsistency error: unexpected incomplete target ...
+```
+
+the derived data cache has likely become corrupted. You can clean it safely with the helper script in `Scripts/clean_build.sh`:
+
+```bash
+./Scripts/clean_build.sh
+```
+
+After running the script, re-run the build and Xcode will regenerate the cache.
+


### PR DESCRIPTION
## Summary
- add a troubleshooting note for the "no more rows available" build database error
- provide a cleanup script that removes stale XCBuildData caches that trigger the failure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6711b121c8331bc8e3f1fc1fd3136