### PR TITLE
Add early return to initial data seeder

### DIFF
--- a/scoremyday2/Services/InitialDataSeeder.swift
+++ b/scoremyday2/Services/InitialDataSeeder.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct InitialDataSeeder {
+    func runIfNeeded() {
+        return
+    }
+}


### PR DESCRIPTION
## Summary
- add an InitialDataSeeder service that exits runIfNeeded immediately so no default cards are added

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e685fe687c83318f210ffc9b4de34d