### PR TITLE
Remove initial data seeder

### DIFF
--- a/scoremyday2/Services/InitialDataSeeder.swift
+++ b/scoremyday2/Services/InitialDataSeeder.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-struct InitialDataSeeder {
-    func runIfNeeded() {
-        return
-    }
-}


### PR DESCRIPTION
## Summary
- remove the initial data seeder to prevent default cards from appearing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e688c6a8308331be4e91b6f59da472