### PR TITLE
Enable Sign in with Apple entitlement

### DIFF
--- a/scoremyday2/scoremyday2.entitlements
+++ b/scoremyday2/scoremyday2.entitlements
@@ -8,9 +8,13 @@
 	<array>
 		<string>iCloud.com.example.deedstracker</string>
 	</array>
-	<key>com.apple.developer.icloud-services</key>
-	<array>
-		<string>CloudKit</string>
-	</array>
+        <key>com.apple.developer.icloud-services</key>
+        <array>
+                <string>CloudKit</string>
+        </array>
+        <key>com.apple.developer.applesignin</key>
+        <array>
+                <string>Default</string>
+        </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- add the Sign in with Apple entitlement to the app's entitlements plist

## Testing
- not run (not applicable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e68bddee50833180cac00197343e2c