### PR TITLE
Highlight today's stats marker for clarity

### DIFF
--- a/scoremyday2/UI/Pages/StatsPage.swift
+++ b/scoremyday2/UI/Pages/StatsPage.swift
@@ -3,6 +3,17 @@ import Combine
 import CoreData
 import SwiftUI
 
+private struct HighlightedTodaySymbol: MarkSymbol {
+    func makeBody(configuration: Configuration) -> some View {
+        Circle()
+            .fill(Color.white)
+            .overlay(
+                Circle()
+                    .stroke(Color.black, lineWidth: 2)
+            )
+    }
+}
+
 struct StatsPage: View {
     @EnvironmentObject private var appEnvironment: AppEnvironment
     @StateObject private var viewModel = StatsPageViewModel()
@@ -118,20 +129,25 @@ struct StatsPage: View {
                                 x: .value("Today", todayPoint.date),
                                 y: .value("Today Value", todayPoint.value)
                             )
-                            .symbolSize(100)
-                            .foregroundStyle(Color.accentColor)
+                            .symbolSize(110)
+                            .symbol(HighlightedTodaySymbol())
                             .annotation(position: .top) {
                                 VStack(spacing: 4) {
                                     Text("TODAY")
                                         .font(.caption)
                                         .fontWeight(.semibold)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundStyle(.primary)
                                     Text(todayPoint.formattedValue)
                                         .font(.headline)
                                         .fontWeight(.semibold)
+                                        .foregroundStyle(.primary)
                                 }
                                 .padding(8)
-                                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                .background(
+                                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                        .fill(Color.white)
+                                        .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- add a custom mark symbol that renders today's point with a white fill and black outline
- update the today annotation styling to use a white card with a subtle shadow for better contrast

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e68ba62af88331bf740e838479166d